### PR TITLE
Preload all instrument response in API, faster pre-processing

### DIFF
--- a/doc/releasenotes/msnoise-1.5.rst
+++ b/doc/releasenotes/msnoise-1.5.rst
@@ -289,9 +289,14 @@ Plot Updates
 
 * ``msnoise plot ccftime`` now accepts -e (--envelope) and will plot the
   envelope of the ccfs.
+* ``msnoise plot ccftime`` and ``msnoise plot interferogram`` now accept -r
+  (--refilter) to refilter the CCFs before plotting. The argument must be a
+  column-separated string (e.g. ``-r 4:8`` for filtering between 4.0 and 8.0 Hz
+  ).
 * Most plots have better titles (filter details, etc).
 * The dv/v plot now allows averaging over components by passing them as comma-
   separated values.
+
 
 
 Performance and Code improvements

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -1536,8 +1536,8 @@ def preload_instrument_responses(session):
     
     """
     logging.debug('Removing instrument response')
-    response_format = get_config(db, 'response_format')
-    files = glob.glob(os.path.join(get_config(db, 'response_path'), "*"))
+    response_format = get_config(session, 'response_format')
+    files = glob.glob(os.path.join(get_config(session, 'response_path'), "*"))
     channels = []
     if response_format == "inventory":
         for file in files:

--- a/msnoise/plots/ccftime.py
+++ b/msnoise/plots/ccftime.py
@@ -3,7 +3,8 @@ This plot shows the cross-correlation functions (CCF) vs time. The parameters
 allow to plot the daily or the mov-stacked CCF. Filters and components are
 selectable too. The ``--ampli`` argument allows to increase the vertical scale
 of the CCFs. The ``--seismic`` shows the up-going wiggles with a black-filled
-background (very heavy !).
+background (very heavy !). Passing ``--refilter`` allows to bandpass filter
+CCFs before plotting (new in 1.5).
 
 .. include:: clickhelp/msnoise-plot-ccftime.rst
 
@@ -21,11 +22,12 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
 from obspy.signal.filter import envelope as obspy_envelope
+from obspy.signal.filter import bandpass
 from ..api import *
 
 
 def main(sta1, sta2, filterid, components, mov_stack=1, ampli=5, seismic=False,
-         show=False, outfile=None, envelope=False):
+         show=False, outfile=None, envelope=False, refilter=None):
     db = connect()
     maxlag = float(get_config(db, 'maxlag'))
     samples = get_maxlag_samples(db)
@@ -37,6 +39,11 @@ def main(sta1, sta2, filterid, components, mov_stack=1, ampli=5, seismic=False,
     sta2 = sta2.replace('.', '_')
     t = np.arange(samples)/cc_sampling_rate - maxlag
 
+    if refilter:
+        freqmin, freqmax = refilter.split(':')
+        freqmin = float(freqmin)
+        freqmax = float(freqmax)
+
     if sta2 >= sta1:
         pair = "%s:%s" % (sta1, sta2)
         
@@ -46,6 +53,11 @@ def main(sta1, sta2, filterid, components, mov_stack=1, ampli=5, seismic=False,
                                           datelist, mov_stack, format="matrix")
         ax = plt.subplot(111)
         for i, line in enumerate(stack_total):
+            if np.all(np.isnan(line)):
+                continue
+            if refilter:
+                line = bandpass(line, freqmin, freqmax, cc_sampling_rate,
+                                corners=4, zerophase=True)
             if envelope:
                 line = obspy_envelope(line)
             line /= line.max()
@@ -65,9 +77,12 @@ def main(sta1, sta2, filterid, components, mov_stack=1, ampli=5, seismic=False,
         plt.xlabel("Lag Time (s)")
         plt.axhline(0, lw=0.5, c='k')
         plt.grid()
-        plt.title('%s : %s, %s, Filter %d (%.2f - %.2f Hz), Stack %d' %
-                  (sta1.replace('_', '.'), sta2.replace('_', '.'), components,
-                   filterid, low, high, mov_stack))
+        title = '%s : %s, %s, Filter %d (%.2f - %.2f Hz), Stack %d' %\
+                (sta1.replace('_', '.'), sta2.replace('_', '.'), components,
+                 filterid, low, high, mov_stack)
+        if refilter:
+            title += ", Re-filtered (%.2f - %.2f Hz)" % (freqmin, freqmax)
+        plt.title(title)
         plt.scatter(0, [start, ], alpha=0)
         plt.ylim(start-datetime.timedelta(days=ampli),
                  end+datetime.timedelta(days=ampli))

--- a/msnoise/preprocessing.py
+++ b/msnoise/preprocessing.py
@@ -4,7 +4,7 @@ import sys
 import time
 import traceback
 
-from obspy import read_inventory
+
 from obspy.core import UTCDateTime
 from obspy.io.xseed import Parser
 
@@ -17,6 +17,7 @@ from .api import *
 
 
 def preprocess(db, stations, comps, goal_day, params):
+    responses = preload_instrument_responses(db)
     datafiles = {}
     output = Stream()
     for station in stations:
@@ -123,55 +124,22 @@ def preprocess(db, stations, comps, goal_day, params):
 
                 if get_config(db, 'remove_response', isbool=True):
                     logging.debug('Removing instrument response')
-                    response_format = get_config(db, 'response_format')
                     response_prefilt = eval(get_config(db, 'response_prefilt'))
-                    files = glob.glob(os.path.join(get_config(db,
-                                                              'response_path'),
-                                                   "*"))
-                    if response_format == "inventory":
-                        firstinv = True
-                        inventory = None
-                        for file in files:
-                            try:
-                                inv = read_inventory(file)
-                                if firstinv:
-                                    inventory = inv
-                                    firstinv = False
-                                else:
-                                    inventory += inv
-                            except:
-                                traceback.print_exc()
-                                pass
-                        if inventory:
-                            stream.attach_response(inventory)
-                            stream.remove_response(output='VEL',
-                                                   pre_filt=response_prefilt)
-                    elif response_format == "dataless":
-                        for file in files:
-                            try:
-                                p = Parser(file)
-                                datalesspz = p.get_paz(stream[0].id,
-                                                       datetime=UTCDateTime(gd))
-                                break
-                            except:
-                                traceback.print_exc()
-                                continue
-                        stream.simulate(paz_remove=datalesspz,
-                                        remove_sensitivity=True,
-                                        pre_filt=response_prefilt,
-                                        paz_simulate=None,)
-                    elif response_format == "paz":
-                        msg = "Unexpected type for `response_format`: %s" % \
-                              response_format
-                        raise TypeError(msg)
-                    elif response_format == "resp":
-                        msg = "Unexpected type for `response_format`: %s" % \
-                              response_format
-                        raise TypeError(msg)
-                    else:
-                        msg = "Unexpected type for `response_format`: %s" % \
-                              response_format
-                        raise TypeError(msg)
+
+                    response = responses[responses["channel_id"] == stream[0].id]
+                    if len(response) > 1:
+                        response = response[response["start_date"]<UTCDateTime(gd)]
+                        response = response[response["end_date"]>UTCDateTime(gd)]
+                    elif len(response) == 0:
+                        logging.info("No instrument response information "
+                                     "for %s, exiting" % stream[0].id)
+                        sys.exit()
+                    datalesspz = response["paz"].values[0]
+                    stream.simulate(paz_remove=datalesspz,
+                                    remove_sensitivity=True,
+                                    pre_filt=response_prefilt,
+                                    paz_simulate=None, )
+
 
                 for tr in stream:
                     tr.data = tr.data.astype(np.float32)

--- a/msnoise/preprocessing.py
+++ b/msnoise/preprocessing.py
@@ -5,8 +5,7 @@ import time
 import traceback
 
 
-from obspy.core import UTCDateTime
-from obspy.io.xseed import Parser
+from obspy.core import UTCDateTime, Stream, read
 
 try:
     from scikits.samplerate import resample
@@ -16,8 +15,8 @@ except:
 from .api import *
 
 
-def preprocess(db, stations, comps, goal_day, params):
-    responses = preload_instrument_responses(db)
+def preprocess(db, stations, comps, goal_day, params, responses=None):
+
     datafiles = {}
     output = Stream()
     for station in stations:
@@ -139,8 +138,6 @@ def preprocess(db, stations, comps, goal_day, params):
                                     remove_sensitivity=True,
                                     pre_filt=response_prefilt,
                                     paz_simulate=None, )
-
-
                 for tr in stream:
                     tr.data = tr.data.astype(np.float32)
                 output += stream

--- a/msnoise/s03compute_cc.py
+++ b/msnoise/s03compute_cc.py
@@ -209,6 +209,12 @@ def main():
 
     logging.info("Will compute %s" % " ".join(params.components_to_compute))
 
+    if get_config(db, 'remove_response', isbool=True):
+        logging.debug('Pre-loading all instrument response')
+        responses = preload_instrument_responses(db)
+    else:
+        responses = None
+
     while is_next_job(db, jobtype='CC'):
         jobs = get_next_job(db, jobtype='CC')
         stations = []
@@ -239,7 +245,8 @@ def main():
                 comps.append(comp[0])
                 comps.append(comp[1])
         comps = np.unique(comps)
-        basetime, stream = preprocess(db, stations, comps, goal_day, params)
+        basetime, stream = preprocess(db, stations, comps, goal_day, params,
+                                      responses)
 
         # print '##### STREAMS ARE ALL PREPARED AT goal Hz #####'
         dt = 1. / params.goal_sampling_rate

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -544,7 +544,9 @@ def timing(ctx, mov_stack, comp, dttname, filterid, pair, all, show, outfile):
 @click.option('-o', '--outfile', help='Output filename (?=auto)',
               default=None, type=str)
 @click.option('-r', '--refilter', default=None, help='Refilter CCFs before '
-                                                     'plotting')
+                                                     'plotting (e.g. 4:8 for '
+                                                     'filtering CCFs between '
+                                                     '4.0 and 8.0 Hz')
 @click.pass_context
 def interferogram(ctx, sta1, sta2, filterid, comp, mov_stack, show, outfile,
                   refilter):
@@ -573,7 +575,9 @@ def interferogram(ctx, sta1, sta2, filterid, comp, mov_stack, show, outfile,
 @click.option('-e', '--envelope', is_flag=True, help='Plot envelope instead of '
                                                      'time series')
 @click.option('-r', '--refilter', default=None, help='Refilter CCFs before '
-                                                     'plotting')
+                                                     'plotting (e.g. 4:8 for '
+                                                     'filtering CCFs between '
+                                                     '4.0 and 8.0 Hz')
 @click.pass_context
 def ccftime(ctx, sta1, sta2, filterid, comp, mov_stack,
             ampli, seismic, show, outfile, envelope, refilter):

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -543,15 +543,18 @@ def timing(ctx, mov_stack, comp, dttname, filterid, pair, all, show, outfile):
               default=True, type=bool)
 @click.option('-o', '--outfile', help='Output filename (?=auto)',
               default=None, type=str)
+@click.option('-r', '--refilter', default=None, help='Refilter CCFs before '
+                                                     'plotting')
 @click.pass_context
-def interferogram(ctx, sta1, sta2, filterid, comp, mov_stack, show, outfile):
+def interferogram(ctx, sta1, sta2, filterid, comp, mov_stack, show, outfile,
+                  refilter):
     """Plots the interferogram between sta1 and sta2 (parses the CCFs)\n
     STA1 and STA2 must be provided with this format: NET.STA !"""
     if ctx.obj['MSNOISE_custom']:
         from interferogram import main
     else:
         from ..plots.interferogram import main
-    main(sta1, sta2, filterid, comp, mov_stack, show, outfile)
+    main(sta1, sta2, filterid, comp, mov_stack, show, outfile, refilter)
 
 
 @click.command()
@@ -567,11 +570,13 @@ def interferogram(ctx, sta1, sta2, filterid, comp, mov_stack, show, outfile):
               default=True, type=bool)
 @click.option('-o', '--outfile', help='Output filename (?=auto)',
               default=None, type=str)
-@click.option('-e', '--envelope', is_flag=True, help='Plot envelope instead of'
+@click.option('-e', '--envelope', is_flag=True, help='Plot envelope instead of '
                                                      'time series')
+@click.option('-r', '--refilter', default=None, help='Refilter CCFs before '
+                                                     'plotting')
 @click.pass_context
 def ccftime(ctx, sta1, sta2, filterid, comp, mov_stack,
-            ampli, seismic, show, outfile, envelope):
+            ampli, seismic, show, outfile, envelope, refilter):
     """Plots the ccf vs time between sta1 and sta2 (parses the dt/t results)\n
     STA1 and STA2 must be provided with this format: NET.STA !"""
     if ctx.obj['MSNOISE_custom']:
@@ -579,7 +584,7 @@ def ccftime(ctx, sta1, sta2, filterid, comp, mov_stack,
     else:
         from ..plots.ccftime import main
     main(sta1, sta2, filterid, comp, mov_stack, ampli, seismic, show, outfile,
-         envelope)
+         envelope, refilter)
 
 
 @click.command()

--- a/msnoise/test/extra/test_inventory.xml
+++ b/msnoise/test/extra/test_inventory.xml
@@ -1,0 +1,5440 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0">
+  <Source>Erdbebendienst Bayern</Source>
+  <Module>fdsn-stationxml-converter/1.0.0</Module>
+  <ModuleURI>http://www.iris.edu/fdsnstationconverter</ModuleURI>
+  <Created>2014-03-03T11:07:06.198000</Created>
+  <Network code="GR">
+    <Description>GRSN</Description>
+    <Station code="FUR" startDate="2006-12-16T00:00:00">
+      <Latitude unit="DEGREES">48.162899</Latitude>
+      <Longitude unit="DEGREES">11.2752</Longitude>
+      <Elevation>565.0</Elevation>
+      <Site>
+        <Name>Fuerstenfeldbruck, Bavaria, GR-Net</Name>
+      </Site>
+      <CreationDate>2006-12-16T00:00:00</CreationDate>
+      <Channel code="HHZ" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="HHN" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="HHE" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHZ" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHN" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHE" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHZ" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHN" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHE" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="VHZ" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">0.1</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="VHN" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">0.1</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="VHE" locationCode="" startDate="2006-12-16T00:00:00">
+        <Latitude unit="DEGREES">48.162899</Latitude>
+        <Longitude unit="DEGREES">11.2752</Longitude>
+        <Elevation>565.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">0.1</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+    <Station code="WET" startDate="2007-02-02T00:00:00">
+      <Latitude unit="DEGREES">49.144001</Latitude>
+      <Longitude unit="DEGREES">12.8782</Longitude>
+      <Elevation>613.0</Elevation>
+      <Site>
+        <Name>Wettzell, Bavaria, GR-Net</Name>
+      </Site>
+      <CreationDate>2007-02-02T00:00:00</CreationDate>
+      <Channel code="HHZ" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="HHN" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="HHE" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">100.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHZ" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHN" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHE" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">20.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHZ" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHN" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="LHE" locationCode="" startDate="2007-02-02T00:00:00">
+        <Latitude unit="DEGREES">49.144001</Latitude>
+        <Longitude unit="DEGREES">12.8782</Longitude>
+        <Elevation>613.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">1.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>943680000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>629121.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+  <Network code="BW">
+    <Description>BayernNetz</Description>
+    <Station code="RJOB" endDate="2006-12-12T00:00:00" startDate="2001-05-15T00:00:00">
+      <Latitude unit="DEGREES">47.737167</Latitude>
+      <Longitude unit="DEGREES">12.795714</Longitude>
+      <Elevation>860.0</Elevation>
+      <Site>
+        <Name>Jochberg, Bavaria, BW-Net</Name>
+      </Site>
+      <CreationDate>2001-05-15T00:00:00</CreationDate>
+      <Channel code="EHZ" endDate="2006-12-12T00:00:00" locationCode="" startDate="2001-05-15T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>400000000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1000000.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHN" endDate="2006-12-12T00:00:00" locationCode="" startDate="2001-05-15T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>400000000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1000000.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHE" endDate="2006-12-12T00:00:00" locationCode="" startDate="2001-05-15T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>400000000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1000000.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+    <Station code="RJOB" endDate="2007-12-17T00:00:00" startDate="2006-12-13T00:00:00">
+      <Latitude unit="DEGREES">47.737167</Latitude>
+      <Longitude unit="DEGREES">12.795714</Longitude>
+      <Elevation>860.0</Elevation>
+      <Site>
+        <Name>Jochberg, Bavaria, BW-Net</Name>
+      </Site>
+      <CreationDate>2006-12-13T00:00:00</CreationDate>
+      <Channel code="EHZ" endDate="2007-12-17T00:00:00" locationCode="" startDate="2006-12-13T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>671140000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHN" endDate="2007-12-17T00:00:00" locationCode="" startDate="2006-12-13T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>671140000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHE" endDate="2007-12-17T00:00:00" locationCode="" startDate="2006-12-13T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>671140000.0</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="3">
+                <Real>-4.444</Real>
+                <Imaginary>4.444</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-4.444</Real>
+                <Imaginary>-4.444</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-1.083</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+    <Station code="RJOB" startDate="2007-12-17T00:00:00">
+      <Latitude unit="DEGREES">47.737167</Latitude>
+      <Longitude unit="DEGREES">12.795714</Longitude>
+      <Elevation>860.0</Elevation>
+      <Site>
+        <Name>Jochberg, Bavaria, BW-Net</Name>
+      </Site>
+      <CreationDate>2007-12-17T00:00:00</CreationDate>
+      <Channel code="EHZ" locationCode="" startDate="2007-12-17T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>2516800000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHN" locationCode="" startDate="2007-12-17T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>2516800000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="EHE" locationCode="" startDate="2007-12-17T00:00:00">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>2516800000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>60077000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real>0.0</Real>
+                <Imaginary>0.0</Imaginary>
+              </Zero>
+              <Pole number="2">
+                <Real>-0.037004</Real>
+                <Imaginary>0.037016</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real>-0.037004</Real>
+                <Imaginary>-0.037016</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real>-251.33</Real>
+                <Imaginary>0.0</Imaginary>
+              </Pole>
+              <Pole number="5">
+                <Real>-131.04</Real>
+                <Imaginary>-467.29</Imaginary>
+              </Pole>
+              <Pole number="6">
+                <Real>-131.04</Real>
+                <Imaginary>467.29</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1500.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0002260141</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00025390089</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030501859</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001712792</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0003494469</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0004491013</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00026315771</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00078977249</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0005999956</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00096246769</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0002078273</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00087297283</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00060405099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018387201</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00063457899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00086809002</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00098580797</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00095671299</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000575279</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000949518</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030551199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00088152097</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000137322</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000778594</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00079203898</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00065987301</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00057668798</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00053842302</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00088394701</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00096824899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000791898</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042381301</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00042503001</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00068158598</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00073892699</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00059995899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00031821601</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000324455</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00051804801</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00056182401</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00045808699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00024655199</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240772</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00039145499</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00043054199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000357899</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00020118</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00017545601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00030062901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034309301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00029872599</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00018425001</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000121944</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000240478</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00029926599</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.000287795</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00021059001</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000215308</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00034048001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00042618299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046569499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00046067499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000419285</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00035347699</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00027616299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.000198849</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0001301</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882e-05</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801e-06</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099e-07</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003e-08</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay>0.149</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>


### PR DESCRIPTION
discussed in #85 , #87 with Rob. 

This PR should pass transparently. The instrument response of all channels is pre-loaded at pre-processing step (could actually be in compute_cc)
