### PR TITLE
Add a new way to compute_cc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
   - conda install --yes -q -c conda-forge obspy
   - pip install flask-admin
   - pip install markdown
+  - pip install codecov
   - ls -la
 
 install:
@@ -66,3 +67,4 @@ script:
   - mkdir MSNoiseTest
   - cd MSNoiseTest
   - msnoise test
+  - coverage run -m msnoise.test.tests

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -1021,9 +1021,11 @@ def stack(session, data):
     goal_sampling_rate = float(get_config(session, "cc_sampling_rate"))
     data = data[~np.isnan(data).any(axis=1)]
     if stack_method == "linear":
+        logging.debug("Doing a linear stack")
         corr = data.mean(axis=0)
 
     elif stack_method == "pws":
+        logging.debug("Doing a PWS stack")
         corr = np.zeros(data.shape[1], dtype='f8')
         phasestack = np.zeros(data.shape[1], dtype='c8')
         for i in range(data.shape[0]):
@@ -1068,11 +1070,12 @@ def get_results(session, station1, station2, filterid, components, dates,
             i += 1
         except:
             pass
-    logging.debug("Stacking...")
+
     if format == "matrix":
         return i, stack_data
 
     elif format == "stack":
+        logging.debug("Stacking...")
         corr = stack(session, stack_data)
 
         if i > 0:

--- a/msnoise/plots/ccftime.py
+++ b/msnoise/plots/ccftime.py
@@ -67,7 +67,7 @@ def main(sta1, sta2, filterid, components, mov_stack=1, ampli=5, seismic=False,
                 y2 = line*ampli + i + base
                 plt.fill_between(t, y1, y2, where=y2 >= y1, facecolor='k',
                                  interpolate=True)
-
+        low = high = 0.0
         for filterdb in get_filters(db, all=True):
             if filterid == filterdb.ref:
                 low = float(filterdb.low)

--- a/msnoise/plots/distance.py
+++ b/msnoise/plots/distance.py
@@ -75,7 +75,7 @@ def main(filterid, components, ampli=1, show=True, outfile=None,
         
     plt.ylabel("Interstation Distance in km")
     plt.xlabel("Lag Time")
-
+    low = high = 0.0
     for filterdb in get_filters(db, all=True):
         if filterid == filterdb.ref:
             low = float(filterdb.low)

--- a/msnoise/s03compute_cc.py
+++ b/msnoise/s03compute_cc.py
@@ -250,8 +250,9 @@ def main():
 
         # print '##### STREAMS ARE ALL PREPARED AT goal Hz #####'
         dt = 1. / params.goal_sampling_rate
-
+        start_processing = time.time()
         # ITERATING OVER PAIRS #####
+        logging.info("Will do %i pairs" % len(pairs))
         for pair in pairs:
             orig_pair = pair
 
@@ -461,7 +462,7 @@ def main():
 
             logging.info("Finished processing this pair. It took %.2f seconds" % (time.time() - tt))
         clean_scipy_cache()
-        logging.info("Job Finished. It took %.2f seconds" % (time.time() - jt))
+        logging.info("Job Finished. It took %.2f seconds (preprocess: %.2f s & process %.2f s)" % ((time.time() - jt), start_processing-jt, time.time()-start_processing))
         del stream
     logging.info('*** Finished: Compute CC ***')
 

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -253,7 +253,7 @@ def config(set, sync):
             coords = responses[responses["netsta"] == id]
             lon = float(coords["longitude"].values[0])
             lat = float(coords["latitude"].values[0])
-            update_station(db, station.net, station.sta, lat, lon, 0, "DEG", )
+            update_station(db, station.net, station.sta, lon, lat, 0, "DEG", )
             logging.info("Added coordinates (%.5f %.5f) for station %s.%s" %
                         (lon, lat, station.net, station.sta))
         db.close()
@@ -348,6 +348,23 @@ def new_jobs(init, nocc):
 def compute_cc(ctx):
     """Computes the CC jobs (based on the "New Jobs" identified)"""
     from ..s03compute_cc import main
+    from multiprocessing import Process
+    threads = ctx.obj['MSNOISE_threads']
+    delay = ctx.obj['MSNOISE_threadsdelay']
+    processes = []
+    for i in range(threads):
+        p = Process(target=main)
+        p.start()
+        processes.append(p)
+        time.sleep(delay)
+    for p in processes:
+        p.join()
+
+@click.command()
+@click.pass_context
+def compute_cc2(ctx):
+    """Computes the CC jobs (based on the "New Jobs" identified)"""
+    from ..s03compute_no_rotation import main
     from multiprocessing import Process
     threads = ctx.obj['MSNOISE_threads']
     delay = ctx.obj['MSNOISE_threadsdelay']
@@ -683,6 +700,7 @@ cli.add_command(bugreport)
 cli.add_command(scan_archive)
 cli.add_command(new_jobs)
 cli.add_command(compute_cc)
+cli.add_command(compute_cc2)
 cli.add_command(stack)
 cli.add_command(compute_mwcs)
 cli.add_command(compute_stretching)


### PR DESCRIPTION
This method is much more efficient when the number of stations (and components) is large.

As is, it's mainly designed to compute "raw" components, without rotation. This allows a common normalization between the horizontal components= allows to compute the rotation after computing the CCFs.