### PR TITLE
Fixes bug with get_stations() returning query objects

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -323,15 +323,15 @@ def get_stations(session, all=False, net=None):
     if all:
         if net is not None:
             stations = q.filter(Station.net == net).order_by(Station.net).\
-                order_by(Station.sta)
+                order_by(Station.sta).all()
         else:
             stations = q.order_by(Station.net).order_by(Station.sta).all()
     else:
         stations = q.filter(Station.used == True).order_by(Station.net).\
-            order_by(Station.sta)
+            order_by(Station.sta).all()
         if net is not None:
             stations = stations.filter(Station.net == net).\
-                order_by(Station.net).order_by(Station.sta)
+                order_by(Station.net).order_by(Station.sta).all()
     return stations
 
 

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -97,7 +97,7 @@ class MSNoiseTests(unittest.TestCase):
     def test_006_get_stations(self):
         from ..api import connect, get_stations
         db = connect()
-        stations = get_stations(db).all()
+        stations = get_stations(db)
         self.failUnlessEqual(len(stations), 3)
         db.close()
 


### PR DESCRIPTION
get_station() was returning query objects instead of list of station. The fix is simple, but why there were a workaround in the test? :(