### PR TITLE
Adds validation to value field in Config model

### DIFF
--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -174,10 +174,11 @@ class Config(Base):
             "output_folder",
             "response_path"
         ]
+
+        value = value.strip() if value is not None else None
         if self.name in fields_to_skip:
             return value
 
-        value = value.strip() if value is not None else None
         value = value.replace(" ", "") if value is not None else None
         return value
 

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -3,6 +3,7 @@ import datetime
 from sqlalchemy import Column, Integer, String, Float, Boolean, DateTime,\
     text, TIMESTAMP, Enum, REAL, UniqueConstraint, Index
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import validates
 
 Base = declarative_base()
 
@@ -161,6 +162,16 @@ class Config(Base):
         """"""
         self.name = name
         self.value = value
+
+    @validates('value')
+    def strip_value(self, key, value):
+        """
+        Strips the input value out of all trailing and leading whitespaces.
+        It also removes all spaces in the string.
+        """
+        value = value.strip() if value is not None else None
+        value = value.replace(" ", "") if value is not None else None
+        return value
 
 ########################################################################
 

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -163,12 +163,20 @@ class Config(Base):
         self.name = name
         self.value = value
 
-    @validates('value')
+    @validates("value")
     def strip_value(self, key, value):
         """
         Strips the input value out of all trailing and leading whitespaces.
         It also removes all spaces in the string.
         """
+        fields_to_skip = [
+            "data_folder",
+            "output_folder",
+            "response_path"
+        ]
+        if self.name in fields_to_skip:
+            return value
+
         value = value.strip() if value is not None else None
         value = value.replace(" ", "") if value is not None else None
         return value

--- a/msnoise/test/test_msnoise_table_def.py
+++ b/msnoise/test/test_msnoise_table_def.py
@@ -1,0 +1,49 @@
+import unittest
+from msnoise.msnoise_table_def import Config
+
+
+class TestConfig(unittest.TestCase):
+
+    fields_to_skip = ["data_folder", "output_folder", "response_path"]
+
+    before_stripping = [
+        "  xxx  xxx   ",
+        "  xxx  xxx",
+        "xxx  xxx   ",
+        "  xxxxxx   ",
+        "xxx  xxx",
+    ]
+
+    after_stripping =  [
+        "xxx  xxx",
+        "xxx  xxx",
+        "xxx  xxx",
+        "xxxxxx",
+        "xxx  xxx",
+    ]
+
+    after_replacing = "xxxxxx"
+
+
+    def test_strip_value_path_field(self):
+
+        for name in self.fields_to_skip:
+            for before, after in zip(self.before_stripping,
+                                     self.after_stripping):
+                self.assertEqual(after, Config(name, before))
+
+    def test_strip_value_non_path_field(self):
+        name = "definitely_a_name_not_in_config"
+
+        for before in self.before_stripping:
+            self.assertEqual(self.after_replacing, Config(name, before))
+
+def suite():
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(unittest.makeSuite(TestConfig))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
Validator strips all the leading and trailing spaces as well as removes all the spaces inside of the strings. 

The removing all the spaces was included due to problems I faced while trying to calculate correlations for different channels than only ZZ. With channels_to_correlate field containing "ZZ, EE, NN" the script was failing due to taking always first two chars out of substrings made of this string split on commas. In that case it was a space an first channel letter.

I skipped validation for fields containing paths since spaces there could be potentially useful.

Solves #98 

