### PR TITLE
get_results throws exception when dir doesn't exist

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -1053,7 +1053,15 @@ def get_results(session, station1, station2, filterid, components, dates,
     i = 0
     base = os.path.join("STACKS", "%02i" % filterid,
                         "%03i_DAYS" % mov_stack, components,
-                        "%s_%s" % (station1, station2), "%s")
+                        "%s_%s" % (station1, station2))
+
+    if not os.path.exists(base):
+        raise NotADirectoryError('Path ' + base + ' does not exist. Check if '
+                                 'provided station names are following '
+                                 'NETW.STATION pattern.')
+
+    base = os.path.join(base, "%s")
+
     if export_format == "BOTH":
         base += ".MSEED"
         export_format = "MSEED"
@@ -1063,7 +1071,7 @@ def get_results(session, station1, station2, filterid, components, dates,
         base += ".MSEED"
     logging.debug("Reading files...")
     for j, date in enumerate(dates):
-        daystack = base % str(date)
+        daystack = base  % str(date)
         try:
             stack_data[j, :] = read(daystack, format=export_format)[0].data[:]
             i += 1

--- a/msnoise/test/test_api.py
+++ b/msnoise/test/test_api.py
@@ -1,0 +1,41 @@
+from unittest import makeSuite, TestCase, TestSuite, TextTestRunner
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+from datetime import date
+
+from msnoise.api import build_movstack_datelist, get_config, update_config,\
+    get_results
+from msnoise.msnoise_table_def import Base, Config
+
+
+class TestGetResults(TestCase):
+    def setUp(self):
+        # Create a in memory database only once for test suite
+        engine = create_engine('sqlite:///')
+        Base.metadata.create_all(engine)
+
+        make_session = sessionmaker(bind=engine)
+        self.session = make_session()
+
+        self.session.add(Config(name="maxlag",
+                                value=120.0))
+        self.session.add(Config(name='cc_sampling_rate',
+                                value=12.0))
+
+
+    def test_get_results_fail_non_esisting_path(self):
+        with self.assertRaises(NotADirectoryError):
+            get_results(self.session, "AABBGGRR", "BBCCDD", 1, "ZZ",
+                        [0,1,2,3,4])
+
+
+def suite():
+    testsuite = TestSuite()
+    testsuite.addTest(makeSuite(TestGetResults))
+
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
I create a separate pull request to extract this feature from PR#101.

This just checks if directory created out from provided station names exists. In case it doesn't, an exception is being thrown.

There is also added a test for that exception throwing.
