### PR TITLE
MWCS: check if REF stack present

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,3 +7,4 @@ Aurélien Mordret
 Lukas E. Preiswerk
 Carmelo Sammarco
 Arnaud Watlet
+Ashton Flinders

--- a/msnoise/s05compute_mwcs.py
+++ b/msnoise/s05compute_mwcs.py
@@ -136,6 +136,9 @@ def main():
                 rf = os.path.join("STACKS", "%02i" %
                                   filterid, "REF", components,
                                   ref_name + extension)
+                # check to see if the ref file exists for this component
+                if not os.path.isfile(rf):
+                    continue
                 ref = read(rf)[0].data
                 for day in days:
                     for mov_stack in mov_stacks:


### PR DESCRIPTION
Small change added to compute_mwcs, to check for reference file existence at each component step so it doesnt crash if the component is missing.