### PR TITLE
Fix use of table prefix in database creation

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -30,7 +30,17 @@ from obspy import read_inventory
 from obspy.io.xseed import Parser
 from obspy.geodetics import gps2dist_azimuth
 
-from .msnoise_table_def import Filter, Job, Station, Config, DataAvailability
+from .msnoise_table_def import declare_tables
+
+
+# Declare mapped tables
+sqlschema = declare_tables()
+Filter = sqlschema.Filter
+Job = sqlschema.Job
+Config = sqlschema.Config
+Station = sqlschema.Station
+DataAvailability = sqlschema.DataAvailability
+
 
 # TODO do we really need this here?
 plugin_tables = {}
@@ -280,7 +290,7 @@ def get_filters(session, all=False):
     :param all: Returns all filters from the database if True, or only filters
         where `used` = 1 if False (default)
 
-    :rtype: list of :class:`~msnoise.msnoise_table_def.Filter`
+    :rtype: list of :class:`~msnoise.msnoise_table_def.declare_tables.Filter`
     :returns: a list of Filter
     """
 
@@ -295,7 +305,7 @@ def update_filter(session, ref, low, mwcs_low, high, mwcs_high,
                   rms_threshold, mwcs_wlen, mwcs_step, used):
     """Updates or Insert a new Filter in the database.
 
-    .. seealso:: :class:`msnoise.msnoise_table_def.Filter`
+    .. seealso:: :class:`msnoise.msnoise_table_def.declare_tables.Filter`
 
     :type session: :class:`sqlalchemy.orm.session.Session`
     :param session: A :class:`~sqlalchemy.orm.session.Session` object, as
@@ -382,8 +392,8 @@ def get_stations(session, all=False, net=None):
     :type net: str
     :param net: if set, limits the stations returned to this network
 
-    :rtype: list of :class:`msnoise.msnoise_table_def.Station`
-    :returns: list of :class:`~msnoise.msnoise_table_def.Station`
+    :rtype: list of :class:`msnoise.msnoise_table_def.declare_tables.Station`
+    :returns: list of :class:`~msnoise.msnoise_table_def.declare_tables.Station`
     """
     q = session.query(Station)
     if all:
@@ -412,8 +422,8 @@ def get_station(session, net, sta):
     :type sta: str
     :param sta: the station code
 
-    :rtype: :class:`msnoise.msnoise_table_def.Station`
-    :returns: a :class:`~msnoise.msnoise_table_def.Station` Object
+    :rtype: :class:`msnoise.msnoise_table_def.declare_tables.Station`
+    :returns: a :class:`~msnoise.msnoise_table_def.declare_tables.Station` Object
 
     """
     station = session.query(Station).filter(Station.net == net).\
@@ -425,7 +435,7 @@ def update_station(session, net, sta, X, Y, altitude, coordinates='UTM',
                    instrument='N/A', used=1):
     """Updates or Insert a new Station in the database.
 
-    .. seealso :: :class:`msnoise.msnoise_table_def.Station`
+    .. seealso :: :class:`msnoise.msnoise_table_def.declare_tables.Station`
     
     :type session: :class:`sqlalchemy.orm.session.Session`
     :param session: A :class:`~sqlalchemy.orm.session.Session` object, as
@@ -480,7 +490,7 @@ def get_station_pairs(session, used=None, net=None):
     :param net: Network code to filter for the pairs.
 
     :rtype: iterable
-    :returns: An iterable of :class:`~msnoise.msnoise_table_def.Station` object
+    :returns: An iterable of :class:`~msnoise.msnoise_table_def.declare_tables.Station` object
         pairs
     """
     stations = get_stations(session, all=False, net=net)
@@ -495,9 +505,9 @@ def get_interstation_distance(station1, station2, coordinates="DEG"):
 
     .. warning:: Currently the stations coordinates system have to be the same!
 
-    :type station1: :class:`~msnoise.msnoise_table_def.Station`
+    :type station1: :class:`~msnoise.msnoise_table_def.declare_tables.Station`
     :param station1: A Station object
-    :type station2: :class:`~msnoise.msnoise_table_def.Station`
+    :type station2: :class:`~msnoise.msnoise_table_def.declare_tables.Station`
     :param station2: A Station object
     :type coordinates: str
     :param coordinates: The coordinates system. "DEG" is WGS84 latitude/
@@ -598,7 +608,7 @@ def get_new_files(session):
         obtained by :func:`connect`
 
     :rtype: list
-    :returns: list of :class:`~msnoise.msnoise_table_def.DataAvailability`
+    :returns: list of :class:`~msnoise.msnoise_table_def.declare_tables.DataAvailability`
     """
 
     files = session.query(DataAvailability).\
@@ -610,7 +620,7 @@ def get_new_files(session):
 def get_data_availability(session, net=None, sta=None, comp=None,
                           starttime=None, endtime=None):
     """
-    Returns the :class:`~msnoise.msnoise_table_def.DataAvailability` objects
+    Returns the :class:`~msnoise.msnoise_table_def.declare_tables.DataAvailability` objects
     for specific `net`, `sta`, `starttime` or `endtime`
 
     :type session: :class:`sqlalchemy.orm.session.Session`
@@ -626,7 +636,7 @@ def get_data_availability(session, net=None, sta=None, comp=None,
     :param endtime: End time of the search
 
     :rtype: list
-    :returns: list of :class:`~msnoise.msnoise_table_def.DataAvailability`
+    :returns: list of :class:`~msnoise.msnoise_table_def.declare_tables.DataAvailability`
     """
 
     if not starttime:
@@ -650,7 +660,7 @@ def get_data_availability(session, net=None, sta=None, comp=None,
 def mark_data_availability(session, net, sta, flag):
     """
     Updates the flag of all
-    :class:`~msnoise.msnoise_table_def.DataAvailability` objects matching
+    :class:`~msnoise.msnoise_table_def.declare_tables.DataAvailability` objects matching
     `net.sta` in the database
 
     :type session: :class:`sqlalchemy.orm.session.Session`
@@ -674,7 +684,7 @@ def mark_data_availability(session, net, sta, flag):
 
 def count_data_availability_flags(session):
     """
-    Count the number of :class:`~msnoise.msnoise_table_def.DataAvailability`,
+    Count the number of :class:`~msnoise.msnoise_table_def.declare_tables.DataAvailability`,
     grouped by `flag`
 
     :type session: :class:`sqlalchemy.orm.session.Session`
@@ -696,7 +706,7 @@ import time
 def update_job(session, day, pair, jobtype, flag, commit=True, returnjob=True,
                ref=None):
     """
-    Updates or Inserts a new :class:`~msnoise.msnoise_table_def.Job` in the
+    Updates or Inserts a new :class:`~msnoise.msnoise_table_def.declare_tables.Job` in the
     database.
 
     :type day: str
@@ -714,7 +724,7 @@ def update_job(session, day, pair, jobtype, flag, commit=True, returnjob=True,
         (False)
 
 
-    :rtype: :class:`~msnoise.msnoise_table_def.Job` or None
+    :rtype: :class:`~msnoise.msnoise_table_def.declare_tables.Job` or None
     :returns: If returnjob is True, returns the modified/inserted Job.
     """
     if ref:
@@ -740,11 +750,11 @@ def update_job(session, day, pair, jobtype, flag, commit=True, returnjob=True,
 def massive_insert_job(jobs):
     """
     Routine to use a low level function to insert much faster a list of
-    :class:`~msnoise.msnoise_table_def.Job`. This method uses the Engine
+    :class:`~msnoise.msnoise_table_def.declare_tables.Job`. This method uses the Engine
     directly, no need to pass a Session object.
 
     :type jobs: list
-    :param jobs: a list of :class:`~msnoise.msnoise_table_def.Job` to insert.
+    :param jobs: a list of :class:`~msnoise.msnoise_table_def.declare_tables.Job` to insert.
     """
     engine = get_engine()
     engine.execute(
@@ -755,11 +765,11 @@ def massive_insert_job(jobs):
 def massive_update_job(session, jobs, flag="D"):
     """
     Routine to use a low level function to update much faster a list of
-    :class:`~msnoise.msnoise_table_def.Job`. This method uses the Job.ref
+    :class:`~msnoise.msnoise_table_def.declare_tables.Job`. This method uses the Job.ref
     which is unique.
 
     :type jobs: list
-    :param jobs: a list of :class:`~msnoise.msnoise_table_def.Job` to update.
+    :param jobs: a list of :class:`~msnoise.msnoise_table_def.declare_tables.Job` to update.
     :type flag: str
     :param flag: The destination flag.
     """
@@ -777,7 +787,7 @@ def massive_update_job(session, jobs, flag="D"):
 
 def is_next_job(session, flag='T', jobtype='CC'):
     """
-    Are there any :class:`~msnoise.msnoise_table_def.Job` in the database,
+    Are there any :class:`~msnoise.msnoise_table_def.declare_tables.Job` in the database,
     with flag=`flag` and jobtype=`type`
 
     :type session: :class:`sqlalchemy.orm.session.Session`
@@ -789,7 +799,7 @@ def is_next_job(session, flag='T', jobtype='CC'):
     :param flag: Status of the Job: "T"odo, "I"n Progress, "D"one.
 
     :rtype: bool
-    :returns: True if at least one :class:`~msnoise.msnoise_table_def.Job`
+    :returns: True if at least one :class:`~msnoise.msnoise_table_def.declare_tables.Job`
         matches, False otherwise.
     """
     job = session.query(Job).with_hint(Job, 'USE INDEX (job_index2)').\
@@ -803,7 +813,7 @@ def is_next_job(session, flag='T', jobtype='CC'):
 
 def get_next_job(session, flag='T', jobtype='CC'):
     """
-    Get the next :class:`~msnoise.msnoise_table_def.Job` in the database,
+    Get the next :class:`~msnoise.msnoise_table_def.declare_tables.Job` in the database,
     with flag=`flag` and jobtype=`jobtype`. Jobs of the same `type` are grouped
     per day. This function also sets the flag of all selected Jobs to "I"n
     progress.
@@ -817,7 +827,7 @@ def get_next_job(session, flag='T', jobtype='CC'):
     :param flag: Status of the Job: "T"odo, "I"n Progress, "D"one.
 
     :rtype: list
-    :returns: list of :class:`~msnoise.msnoise_table_def.Job`
+    :returns: list of :class:`~msnoise.msnoise_table_def.declare_tables.Job`
     """
     tmp = []
     while not len(tmp):
@@ -837,7 +847,7 @@ def get_next_job(session, flag='T', jobtype='CC'):
 
 def is_dtt_next_job(session, flag='T', jobtype='DTT', ref=False):
     """
-    Are there any DTT :class:`~msnoise.msnoise_table_def.Job` in the database,
+    Are there any DTT :class:`~msnoise.msnoise_table_def.declare_tables.Job` in the database,
     with flag=`flag` and jobtype=`jobtype`. If `ref` is provided, checks if a
     DTT "REF" job is present.
 
@@ -869,7 +879,7 @@ def is_dtt_next_job(session, flag='T', jobtype='DTT', ref=False):
 
 def get_dtt_next_job(session, flag='T', jobtype='DTT'):
     """
-    Get the next DTT :class:`~msnoise.msnoise_table_def.Job` in the database,
+    Get the next DTT :class:`~msnoise.msnoise_table_def.declare_tables.Job` in the database,
     with flag=`flag` and jobtype=`jobtype`. Jobs are then grouped per station
     pair. This function also sets the flag of all selected Jobs to "I"n
     progress.

--- a/msnoise/msnoise_admin.py
+++ b/msnoise/msnoise_admin.py
@@ -148,7 +148,17 @@ from flask_wtf import Form
 
 from .api import *
 from .default import default
-from .msnoise_table_def import *
+
+from .msnoise_table_def import declare_tables
+
+
+# Declare mapped tables
+sqlschema = declare_tables()
+Filter = sqlschema.Filter
+Job = sqlschema.Job
+Config = sqlschema.Config
+Station = sqlschema.Station
+DataAvailability = sqlschema.DataAvailability
 
 
 class GenericView(BaseView):

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -1,259 +1,301 @@
-import datetime
+"""
+SQLAlchemy table definition.
+"""
 
+import datetime
+import os
+from collections import namedtuple
 from sqlalchemy import Column, Integer, String, Float, Boolean, DateTime,\
     text, TIMESTAMP, Enum, REAL, UniqueConstraint, Index
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 
-import os
 try:
     import cPickle
 except:
     import pickle as cPickle
-Base = declarative_base()
 
 
-class PrefixerBase(Base):
-    __abstract__ = True
-    _the_prefix = ""
-
-    inifile = os.path.join(os.getcwd(), 'db.ini')
-    if os.path.isfile(inifile):
-        f = open(inifile, 'rb')
-        data = cPickle.load(f)
-        if len(data) == 5:
-            tech, hostname, database, username, password = data
-        else:
-            tech, hostname, database, username, password, prefix = data
-            if prefix != "":
-                _the_prefix = prefix + "_"
-        f.close()
-
-    @declared_attr
-    def __tablename__(cls):
-        return cls._the_prefix + cls.__incomplete_tablename__
+# Name of the file in the current directory that keeps
+# information pointing to the database to use.
+DB_INI = 'db.ini'
 
 
-class Filter(PrefixerBase):
+def read_prefix(db_ini_filename=DB_INI):
     """
-    Filter base class.
-
-    :type ref: int
-    :param ref: The id of the Filter in the database
-    :type low: float
-    :param low: The lower frequency bound of the Whiten function (in Hz)
-    :type high: float
-    :param high: The upper frequency bound of the Whiten function (in Hz)
-    :type mwcs_low: float
-    :param mwcs_low: The lower frequency bound of the linear regression done in
-        MWCS (in Hz)
-    :type mwcs_high: float
-    :param mwcs_high: The upper frequency bound of the linear regression done in
-        MWCS (in Hz)
-    :type rms_threshold: float
-    :param rms_threshold: Not used anymore
-    :type mwcs_wlen: float
-    :param mwcs_wlen: Window length (in seconds) to perform MWCS
-    :type mwcs_step: float
-    :param mwcs_step: Step (in seconds) of the windowing procedure in MWCS
-    :type used: bool
-    :param used: Is the filter activated for the processing
+    Returns the table prefix set in the db_ini_filename file.
     """
-
-    __incomplete_tablename__ = "filters"
-
-    ref = Column(Integer, primary_key=True)
-    low = Column(Float())
-    mwcs_low = Column(Float())
-    high = Column(Float())
-    mwcs_high = Column(Float())
-    rms_threshold = Column(Float())
-    mwcs_wlen = Column(Float())
-    mwcs_step = Column(Float())
-    used = Column(Boolean(True))
-
-    def __init__(self, **kwargs):
-        """"""
-        # self.low = low
-        # self.mwcs_low = mwcs_low
-        # self.high = high
-        # self.mwcs_high = mwcs_high
-        # self.rms_threshold = rms_threshold
-        # self.mwcs_wlen = mwcs_wlen
-        # self.mwcs_step = mwcs_step
-        # self.used = used
+    with open(db_ini_filename, 'rb') as ini_file:
+        data = cPickle.load(ini_file)
+        # Note: data should contain the following table
+        # [tech hostname database username password prefix]
+        # with prefix being optional for backward compatibility
+        try:
+            prefix = data[5]
+        except IndexError:
+            prefix = ''
+    return prefix
 
 
-class Job(PrefixerBase):
+def declare_tables(prefix=None):
     """
-    Job Object
-
-    :type ref: int
-    :param ref: The Job ID in the database
-    :type day: str
-    :param day: The day in YYYY-MM-DD format
-    :type pair: str
-    :param pair: the name of the pair (EXAMPLE?)
-    :type jobtype: str
-    :param jobtype: CrossCorrelation (CC) or dt/t (DTT) Job?
-    :type flag: str
-    :param flag: Status of the Job: "T"odo, "I"n Progress, "D"one.
+    Define classes mapped to relational database tables and return the declared
+    classes in a numedtuple.
     """
-    __incomplete_tablename__ = "jobs"
+    # Implementation note: these definitions must be done in a function to
+    # allow for the prefix to be evaluated at run time. If this was done at
+    # module level, the code would be evaluated at compile time (when the
+    # interpreter starts) and the prefix could not be specified at run time.
 
-    ref = Column(Integer, primary_key=True)
-    day = Column(String(10))
-    pair = Column(String(20))
-    jobtype = Column(String(10))
-    flag = Column(String(1))
-    lastmod = Column(TIMESTAMP, server_onupdate=text('CURRENT_TIMESTAMP'),
-                     server_default=text("CURRENT_TIMESTAMP"))
+    # If no prefix is given, read it from the db.ini file
+    if prefix is None:
+        prefix = read_prefix()
 
-    table_args__ = (Index('job_index', "day", "pair", "jobtype", unique=True),
-                    Index('job_index2', "jobtype", "flag", unique=False))
+    # Define the namedtuple to return
+    sqlschema = namedtuple('SQLSchema', ['Base', 'Filter', 'Job', 'Station',
+        'Config', 'DataAvailability'])
 
-    def __init__(self, day, pair, jobtype, flag,
-                 lastmod=datetime.datetime.utcnow()):
-        """"""
-        self.day = day
-        self.pair = pair
-        self.jobtype = jobtype
-        self.flag = flag
-        self.lastmod = lastmod
+    # Create the SQLAlchemy base and subclass it to prefix the table names
+    Base = declarative_base()
 
+    class PrefixerBase(Base):
+        """
+        A Base abstract subclass that will add our prefix to table names.
+        """
+        __abstract__ = True
 
-class Station(PrefixerBase):
-    """
-    Station Object
+        @declared_attr
+        def __tablename__(cls):
+            table_prefix = prefix
+            if prefix:
+                table_prefix += '_'
+            return table_prefix + cls.__incomplete_tablename__
 
-    :type ref: int
-    :param ref: The Station ID in the database
-    :type net: str
-    :param net: The network code of the Station
-    :type sta: str
-    :param sta: The station code
-    :type X: float
-    :param X: The X coordinate of the station
-    :type Y: float
-    :param Y: The Y coordinate of the station
-    :type altitude: float
-    :param altitude: The altitude of the station
-    :type coordinates: str
-    :param coordinates: The coordinates system. "DEG" is WGS84 latitude/
-        longitude in degrees. "UTM" is expressed in meters.
-    :type instrument: str
-    :param instrument: The instrument code, useful with PAZ correction
-    :type used: bool
-    :param used: Whether this station must be used in the computations.
-    """
-    __incomplete_tablename__ = "stations"
-    ref = Column(Integer, primary_key=True)
-    net = Column(String(10))
-    sta = Column(String(10))
-    X = Column(REAL())
-    Y = Column(REAL())
-    altitude = Column(Float())
-    coordinates = Column(Enum('DEG', 'UTM'))
-    instrument = Column(String(20))
-    used = Column(Boolean)
+    ########################################################################
 
-    def __init__(self, *args):
-        """"""
-        if len(args):
-            self.net = args[0]
-            self.sta = args[1]
-            self.X = args[2]
-            self.Y = args[3]
-            self.altitude = args[4]
-            self.coordinates = args[5]
-            self.instrument = args[6]
-            self.used = args[7]
+    class Filter(PrefixerBase):
+        """
+        Filter base class.
 
-########################################################################
+        :type ref: int
+        :param ref: The id of the Filter in the database
+        :type low: float
+        :param low: The lower frequency bound of the Whiten function (in Hz)
+        :type high: float
+        :param high: The upper frequency bound of the Whiten function (in Hz)
+        :type mwcs_low: float
+        :param mwcs_low: The lower frequency bound of the linear regression done in
+            MWCS (in Hz)
+        :type mwcs_high: float
+        :param mwcs_high: The upper frequency bound of the linear regression done in
+            MWCS (in Hz)
+        :type rms_threshold: float
+        :param rms_threshold: Not used anymore
+        :type mwcs_wlen: float
+        :param mwcs_wlen: Window length (in seconds) to perform MWCS
+        :type mwcs_step: float
+        :param mwcs_step: Step (in seconds) of the windowing procedure in MWCS
+        :type used: bool
+        :param used: Is the filter activated for the processing
+        """
 
+        __incomplete_tablename__ = "filters"
 
-class Config(PrefixerBase):
-    """
-    Config Object
+        ref = Column(Integer, primary_key=True)
+        low = Column(Float())
+        mwcs_low = Column(Float())
+        high = Column(Float())
+        mwcs_high = Column(Float())
+        rms_threshold = Column(Float())
+        mwcs_wlen = Column(Float())
+        mwcs_step = Column(Float())
+        used = Column(Boolean(True))
 
-    :type name: str
-    :param name: The name of the config bit to set.
+        def __init__(self, **kwargs):
+            """"""
+            # self.low = low
+            # self.mwcs_low = mwcs_low
+            # self.high = high
+            # self.mwcs_high = mwcs_high
+            # self.rms_threshold = rms_threshold
+            # self.mwcs_wlen = mwcs_wlen
+            # self.mwcs_step = mwcs_step
+            # self.used = used
 
-    :type value: str
-    :param value: The value of parameter `name`
-    """
-    __incomplete_tablename__ = "config"
-    name = Column(String(255), primary_key=True)
-    value = Column(String(255))
+    ########################################################################
 
-    def __init__(self, name, value):
-        """"""
-        self.name = name
-        self.value = value
+    class Job(PrefixerBase):
+        """
+        Job Object
 
-########################################################################
+        :type ref: int
+        :param ref: The Job ID in the database
+        :type day: str
+        :param day: The day in YYYY-MM-DD format
+        :type pair: str
+        :param pair: the name of the pair (EXAMPLE?)
+        :type jobtype: str
+        :param jobtype: CrossCorrelation (CC) or dt/t (DTT) Job?
+        :type flag: str
+        :param flag: Status of the Job: "T"odo, "I"n Progress, "D"one.
+        """
+        __incomplete_tablename__ = "jobs"
 
+        ref = Column(Integer, primary_key=True)
+        day = Column(String(10))
+        pair = Column(String(20))
+        jobtype = Column(String(10))
+        flag = Column(String(1))
+        lastmod = Column(TIMESTAMP, server_onupdate=text('CURRENT_TIMESTAMP'),
+                         server_default=text("CURRENT_TIMESTAMP"))
 
-class DataAvailability(PrefixerBase):
-    """
-    DataAvailability Object
+        table_args__ = (Index('job_index', "day", "pair", "jobtype", unique=True),
+                        Index('job_index2', "jobtype", "flag", unique=False))
 
-    :type ref: int
-    :param ref: The Station ID in the database
-    :type net: str
-    :param net: The network code of the Station
-    :type sta: str
-    :param sta: The station code
-    :type comp: str
-    :param comp: The component (channel)
-    :type path: str
-    :param path: The full path to the folder containing the file
-    :type file: str
-    :param file: The name of the file
-    :type starttime: datetime
-    :param starttime: Start time of the file
-    :type endtime: datetime
-    :param endtime: End time of the file
-    :type data_duration: float
-    :param data_duation: Cumulative duration of available data in the file
-    :type gaps_duration: float
-    :param gaps_duration: Cumulative duration of gaps in the file
-    :type samplerate: float
-    :param samplerate: Sample rate of the data in the file (in Hz)
-    :type flag: str
-    :param flag: The status of the entry: "N"ew, "M"odified or "A"rchive
-    """
-    __incomplete_tablename__ = "data_availability"
-    ref = Column(Integer, primary_key=True, autoincrement=True)
-    net = Column(String(10))
-    sta = Column(String(10))
-    comp = Column(String(20))
-    path = Column(String(255))
-    file = Column(String(255))
-    starttime = Column(DateTime)
-    endtime = Column(DateTime)
-    data_duration = Column(Float)
-    gaps_duration = Column(Float)
-    samplerate = Column(Float)
-    flag = Column(String(1))
-    # UniqueConstraint('net', 'sta', 'comp', 'filename', name='uix_1')
-    table_args__ = (Index('da_index',
-                          "path",
-                          "file",
-                          "net",
-                          "sta",
-                          "comp", unique=True),)
+        def __init__(self, day, pair, jobtype, flag,
+                     lastmod=datetime.datetime.utcnow()):
+            """"""
+            self.day = day
+            self.pair = pair
+            self.jobtype = jobtype
+            self.flag = flag
+            self.lastmod = lastmod
 
-    def __init__(self, net, sta, comp, path, file, starttime, endtime,
-                 data_duration, gaps_duration, samplerate, flag):
-        """"""
-        self.net = net
-        self.sta = sta
-        self.comp = comp
-        self.path = path
-        self.file = file
-        self.starttime = starttime
-        self.endtime = endtime
-        self.data_duration = data_duration
-        self.gaps_duration = gaps_duration
-        self.samplerate = samplerate
-        self.flag = flag
+    class Station(PrefixerBase):
+        """
+        Station Object
+
+        :type ref: int
+        :param ref: The Station ID in the database
+        :type net: str
+        :param net: The network code of the Station
+        :type sta: str
+        :param sta: The station code
+        :type X: float
+        :param X: The X coordinate of the station
+        :type Y: float
+        :param Y: The Y coordinate of the station
+        :type altitude: float
+        :param altitude: The altitude of the station
+        :type coordinates: str
+        :param coordinates: The coordinates system. "DEG" is WGS84 latitude/
+            longitude in degrees. "UTM" is expressed in meters.
+        :type instrument: str
+        :param instrument: The instrument code, useful with PAZ correction
+        :type used: bool
+        :param used: Whether this station must be used in the computations.
+        """
+        __incomplete_tablename__ = "stations"
+        ref = Column(Integer, primary_key=True)
+        net = Column(String(10))
+        sta = Column(String(10))
+        X = Column(REAL())
+        Y = Column(REAL())
+        altitude = Column(Float())
+        coordinates = Column(Enum('DEG', 'UTM'))
+        instrument = Column(String(20))
+        used = Column(Boolean)
+
+        def __init__(self, *args):
+            """"""
+            if len(args):
+                self.net = args[0]
+                self.sta = args[1]
+                self.X = args[2]
+                self.Y = args[3]
+                self.altitude = args[4]
+                self.coordinates = args[5]
+                self.instrument = args[6]
+                self.used = args[7]
+
+    ########################################################################
+
+    class Config(PrefixerBase):
+        """
+        Config Object
+
+        :type name: str
+        :param name: The name of the config bit to set.
+
+        :type value: str
+        :param value: The value of parameter `name`
+        """
+        __incomplete_tablename__ = "config"
+        name = Column(String(255), primary_key=True)
+        value = Column(String(255))
+
+        def __init__(self, name, value):
+            """"""
+            self.name = name
+            self.value = value
+
+    ########################################################################
+
+    class DataAvailability(PrefixerBase):
+        """
+        DataAvailability Object
+
+        :type ref: int
+        :param ref: The Station ID in the database
+        :type net: str
+        :param net: The network code of the Station
+        :type sta: str
+        :param sta: The station code
+        :type comp: str
+        :param comp: The component (channel)
+        :type path: str
+        :param path: The full path to the folder containing the file
+        :type file: str
+        :param file: The name of the file
+        :type starttime: datetime
+        :param starttime: Start time of the file
+        :type endtime: datetime
+        :param endtime: End time of the file
+        :type data_duration: float
+        :param data_duation: Cumulative duration of available data in the file
+        :type gaps_duration: float
+        :param gaps_duration: Cumulative duration of gaps in the file
+        :type samplerate: float
+        :param samplerate: Sample rate of the data in the file (in Hz)
+        :type flag: str
+        :param flag: The status of the entry: "N"ew, "M"odified or "A"rchive
+        """
+        __incomplete_tablename__ = "data_availability"
+        ref = Column(Integer, primary_key=True, autoincrement=True)
+        net = Column(String(10))
+        sta = Column(String(10))
+        comp = Column(String(20))
+        path = Column(String(255))
+        file = Column(String(255))
+        starttime = Column(DateTime)
+        endtime = Column(DateTime)
+        data_duration = Column(Float)
+        gaps_duration = Column(Float)
+        samplerate = Column(Float)
+        flag = Column(String(1))
+        # UniqueConstraint('net', 'sta', 'comp', 'filename', name='uix_1')
+        table_args__ = (Index('da_index',
+                              "path",
+                              "file",
+                              "net",
+                              "sta",
+                              "comp", unique=True),)
+
+        def __init__(self, net, sta, comp, path, file, starttime, endtime,
+                     data_duration, gaps_duration, samplerate, flag):
+            """"""
+            self.net = net
+            self.sta = sta
+            self.comp = comp
+            self.path = path
+            self.file = file
+            self.starttime = starttime
+            self.endtime = endtime
+            self.data_duration = data_duration
+            self.gaps_duration = gaps_duration
+            self.samplerate = samplerate
+            self.flag = flag
+
+    ########################################################################
+
+    return sqlschema(Base, Filter, Job, Station, Config, DataAvailability)
+    # end of declare_tables()

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -31,7 +31,7 @@ def read_prefix(db_ini_filename=DB_INI):
             # [tech hostname database username password prefix]
             # with prefix being optional for backward compatibility
             return data[5]
-    except (IndexError, FileNotFoundError):
+    except (IndexError, IOError):
         return ''
 
 

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -24,16 +24,15 @@ def read_prefix(db_ini_filename=DB_INI):
     """
     Returns the table prefix set in the db_ini_filename file.
     """
-    with open(db_ini_filename, 'rb') as ini_file:
-        data = cPickle.load(ini_file)
-        # Note: data should contain the following table
-        # [tech hostname database username password prefix]
-        # with prefix being optional for backward compatibility
-        try:
-            prefix = data[5]
-        except IndexError:
-            prefix = ''
-    return prefix
+    try:
+        with open(db_ini_filename, 'rb') as ini_file:
+            data = cPickle.load(ini_file)
+            # Note: data should contain the following table
+            # [tech hostname database username password prefix]
+            # with prefix being optional for backward compatibility
+            return data[5]
+    except (IndexError, FileNotFoundError):
+        return ''
 
 
 def declare_tables(prefix=None):

--- a/msnoise/s000installer.py
+++ b/msnoise/s000installer.py
@@ -118,8 +118,15 @@ def create_indices(session):
         session.rollback()
 
 
-def main(tech=None):
+def main(tech=None, hostname=None, username=None, password=None,
+         database=None, filename=None, prefix=None):
     """
+    Create the db.ini file and create database.
+
+    Interactively ask database type and connection information to the user,
+    write them to the db.ini file and create the database tables.
+    Information input by the user must also be allowed to be passed as function
+    argument for the automatic tests.
     """
     if tech is None:
         print("Welcome to MSNoise")
@@ -142,24 +149,31 @@ def main(tech=None):
             return input_func(prompt.format(default)) or default
 
         if tech == 1:
-            filename = ask('Filename: [{}]: ',
-                           DEFAULT_INPUTS['sqlite_filename'])
-            prefix = ask('Table prefix: []: ', '')
+            if filename is None:
+                filename = ask('Filename: [{}]: ',
+                               DEFAULT_INPUTS['sqlite_filename'])
+            if prefix is None:
+                prefix = ask('Table prefix: []: ', '')
             database = None
             username = None
             password = None
         else:
-            hostname = ask('Server: [{}]: ', DEFAULT_INPUTS['mysql_host'])
-            database = ask('Database: [{}]: ', DEFAULT_INPUTS['mysql_db'])
-            username = ask('Username: [{}]: ', DEFAULT_INPUTS['mysql_user'])
-            password = ''
-            while not password:
-                password = ask('Password (not shown as you type): ',
-                               '', getpass)
-                if not password:
-                    print('Sorry, you must define a password.')
-            prefix = ask('Table prefix: [{}]: ',
-                         DEFAULT_INPUTS['table_prefix'])
+            if hostname is None:
+                hostname = ask('Server: [{}]: ', DEFAULT_INPUTS['mysql_host'])
+            if database is None:
+                database = ask('Database: [{}]: ', DEFAULT_INPUTS['mysql_db'])
+            if username is None:
+                username = ask('Username: [{}]: ', DEFAULT_INPUTS['mysql_user'])
+            if password is None:
+                password = ''
+                while not password:
+                    password = ask('Password (not shown as you type): ',
+                                   '', getpass)
+                    if not password:
+                        print('Sorry, you must define a password.')
+            if prefix is None:
+                prefix = ask('Table prefix: [{}]: ',
+                             DEFAULT_INPUTS['table_prefix'])
     else:
         tech = int(tech)
 
@@ -192,9 +206,10 @@ def main(tech=None):
     except IntegrityError:
         logging.error("The database seems to already exist and is not empty, "
                       "cannot continue")
-        return
+        return 1
 
     create_indices(session)
 
     session.close()
     print("Installation Done! - Go to Configuration Step!")
+    return 0

--- a/msnoise/s000installer.py
+++ b/msnoise/s000installer.py
@@ -88,11 +88,13 @@ def create_database_inifile(tech, hostname, database, username, password,
     f.close()
 
 
-def create_indices(session):
+def create_indices(session, prefix):
     """
     Create indices in the database, using the provided sqlalchemy session.
     """
     # TODO move those calls to a def and call it from install / msnoise.scripts
+    if prefix:
+        prefix += '_'
     try:
         session.execute("CREATE UNIQUE INDEX job_index ON %sjobs (day, pair, "
                         "jobtype)" % prefix)
@@ -208,7 +210,7 @@ def main(tech=None, hostname=None, username=None, password=None,
                       "cannot continue")
         return 1
 
-    create_indices(session)
+    create_indices(session, prefix)
 
     session.close()
     print("Installation Done! - Go to Configuration Step!")

--- a/msnoise/s001configurator.py
+++ b/msnoise/s001configurator.py
@@ -22,12 +22,12 @@ Default Global Parameters
 Network-Station Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. seealso :: :class:`msnoise.msnoise_table_def.Station`
+.. seealso :: :class:`msnoise.msnoise_table_def.declare_tables.Station`
 
 Filter Parameters
 ~~~~~~~~~~~~~~~~~
 
-.. seealso :: :class:`msnoise.msnoise_table_def.Filter`
+.. seealso :: :class:`msnoise.msnoise_table_def.declare_tables.Filter`
 
 """
 
@@ -38,7 +38,6 @@ from traitsui.table_column import ObjectColumn
 
 from .api import *
 from .default import *
-from .msnoise_table_def import *
 
 
 class StationColumn (ObjectColumn):

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -7,8 +7,8 @@ import time
 import click
 import pkg_resources
 
-
-# from click_plugins import with_plugins
+from ..msnoise_table_def import declare_tables
+from ..api import update_station
 
 
 @click.group()
@@ -381,8 +381,8 @@ def populate(fromda):
     """Rapidly scan the archive filenames and find Network/Stations"""
     if fromda:
         logging.info("Overriding workflow...")
-        from ..msnoise_table_def import DataAvailability
-        from ..api import update_station
+        sqlschema = declare_tables()
+        DataAvailability = sqlschema.DataAvailability
         db = connect()
         stations = db.query(DataAvailability.net, DataAvailability.sta). \
             group_by(DataAvailability.net, DataAvailability.sta)

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -403,9 +403,8 @@ class MSNoiseTests(unittest.TestCase):
         from ..s000installer import main
         try:
             ret = main(tech=2, username="root", password="",
-                       hostname="localhost", database="msnoise")
-            msg = "Installation Done! - Go to Configuration Step!"
-            self.failUnlessEqual(ret, msg)
+                       hostname="localhost", database="msnoise", prefix="")
+            self.failUnlessEqual(ret, 0)
         except:
             traceback.print_exc()
             self.fail()

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -30,8 +30,7 @@ class MSNoiseTests(unittest.TestCase):
             self.prefix=os.environ["PREFIX"]
         try:
             ret = main(tech=1, prefix=self.prefix)
-            msg = "Installation Done! - Go to Configuration Step!"
-            self.failUnlessEqual(ret, msg)
+            self.failUnlessEqual(ret, 0)
         except:
             traceback.print_exc()
             self.fail()
@@ -61,9 +60,7 @@ class MSNoiseTests(unittest.TestCase):
         db.close()
 
     def test_004_set_and_get_filters(self):
-        from ..msnoise_table_def import declare_tables
-        Filter = declare_tables().Filter
-        from ..api import connect, update_filter, get_filters
+        from ..api import connect, update_filter, get_filters, Filter
         db = connect()
         filters = []
         f = Filter()
@@ -168,9 +165,7 @@ class MSNoiseTests(unittest.TestCase):
             self.fail()
 
     def test_011_control_jobs(self):
-        from ..api import connect, is_next_job, get_next_job
-        from ..msnoise_table_def import declare_tables
-        Job = declare_tables().Job
+        from ..api import connect, is_next_job, get_next_job, Job
         db = connect()
 
         self.failUnlessEqual(is_next_job(db), True)

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -61,7 +61,8 @@ class MSNoiseTests(unittest.TestCase):
         db.close()
 
     def test_004_set_and_get_filters(self):
-        from ..msnoise_table_def import Filter
+        from ..msnoise_table_def import declare_tables
+        Filter = declare_tables().Filter
         from ..api import connect, update_filter, get_filters
         db = connect()
         filters = []
@@ -168,7 +169,8 @@ class MSNoiseTests(unittest.TestCase):
 
     def test_011_control_jobs(self):
         from ..api import connect, is_next_job, get_next_job
-        from ..msnoise_table_def import Job
+        from ..msnoise_table_def import declare_tables
+        Job = declare_tables().Job
         db = connect()
 
         self.failUnlessEqual(is_next_job(db), True)


### PR DESCRIPTION
msnoise_table_def.py was defining the table names and reading the prefix
from the db.ini file at compilation time, right after the interpreter
starts (as the code was at module level, in the class declaration).

As a consequence, on a new project (with no db.ini file), the prefix
chosen by the user was added to the db.ini file but ignored when
creating the tables, which were always created without any prefix. When
re-initialising the database (when a db.ini already exists), only the
prefix written in db.ini during the last run of 'msnoise db init' was
used, and again, the prefix entered by the user was ignored and simply
stored in db.ini.

As SQLAlchemy Declarative system sets up the classes mapped to
relational database tables as soon as they are defined, this definition
has to be postponed to run-time to allow the table names to use a prefix
entered by the user.

The changes introduced by this commit move the definition of the mapped
classes to a function to allow the use of a prefix entered before by the
user (when initialising a new database) or read from the db.ini file
(when using an existing database).

Modules using these mapped classes are updated to call the function
defining the mapped class instead of directly importing the classes.

Additionally, the s000installer.py file is reworked for better
readability and maintainability:

 - indices are created in their own function

 - user input for database and password choice somewhat improved

 - improved readability and maintainability of code handling default
   values in user choices

 - for security, no default password is provided (to avoid weak default
   installation)