### PR TITLE
Improve error handling

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-Xavier Beguin
+Xavier Béguin
 Corentin Caudron
 Clare Donaldson
 Raphaël De Plaen

--- a/msnoise/__init__.py
+++ b/msnoise/__init__.py
@@ -7,3 +7,10 @@ __maintainer__ = "Thomas LECOCQ"
 __email__ = "Thomas.Lecocq at seismology.be"
 __status__ = "Production"
 
+
+class MSNoiseError(Exception):
+    pass
+
+
+class DBConfigNotFoundError(MSNoiseError):
+    pass

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -3,7 +3,6 @@ import datetime
 import itertools
 import logging
 import os
-import sys
 import glob
 import traceback
 try:
@@ -30,6 +29,7 @@ from obspy import read_inventory
 from obspy.io.xseed import Parser
 from obspy.geodetics import gps2dist_azimuth
 
+from . import DBConfigNotFoundError
 from .msnoise_table_def import Filter, Job, Station, Config, DataAvailability
 
 
@@ -130,11 +130,12 @@ def read_database_inifile(inifile=None):
 
     try:
         f = open(inifile, 'rb')
-    except FileNotFoundError:
-        print("No db.ini file in this directory, please run "
-                     "'msnoise db init' in this folder to initialize it as "
-                     "an MSNoise project folder.")
-        sys.exit(1)
+    #except FileNotFoundError:  # This is better but only for python3
+    except IOError:
+        raise DBConfigNotFoundError(
+                "No db.ini file in this directory, please run "
+                "'msnoise db init' in this folder to initialize it as "
+                "an MSNoise project folder.")
     try:
         # New ini file with prefix support
         tech, hostname, database, username, password, prefix = cPickle.load(f)

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -30,17 +30,7 @@ from obspy import read_inventory
 from obspy.io.xseed import Parser
 from obspy.geodetics import gps2dist_azimuth
 
-from .msnoise_table_def import declare_tables
-
-
-# Declare mapped tables
-sqlschema = declare_tables()
-Filter = sqlschema.Filter
-Job = sqlschema.Job
-Config = sqlschema.Config
-Station = sqlschema.Station
-DataAvailability = sqlschema.DataAvailability
-
+from .msnoise_table_def import Filter, Job, Station, Config, DataAvailability
 
 
 def get_tech():

--- a/msnoise/msnoise_admin.py
+++ b/msnoise/msnoise_admin.py
@@ -149,16 +149,7 @@ from flask_wtf import Form
 from .api import *
 from .default import default
 
-from .msnoise_table_def import declare_tables
-
-
-# Declare mapped tables
-sqlschema = declare_tables()
-Filter = sqlschema.Filter
-Job = sqlschema.Job
-Config = sqlschema.Config
-Station = sqlschema.Station
-DataAvailability = sqlschema.DataAvailability
+from .msnoise_table_def import Filter, Job, Station, Config, DataAvailability
 
 
 class GenericView(BaseView):

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -50,8 +50,8 @@ def declare_tables(prefix=None):
         prefix = read_prefix()
 
     # Define the namedtuple to return
-    sqlschema = namedtuple('SQLSchema', ['Base', 'Filter', 'Job', 'Station',
-        'Config', 'DataAvailability'])
+    sqlschema = namedtuple('SQLSchema', ['Base', 'PrefixerBase', 'Filter',
+        'Job', 'Station', 'Config', 'DataAvailability'])
 
     # Create the SQLAlchemy base and subclass it to prefix the table names
     Base = declarative_base()
@@ -296,5 +296,11 @@ def declare_tables(prefix=None):
 
     ########################################################################
 
-    return sqlschema(Base, Filter, Job, Station, Config, DataAvailability)
+    return sqlschema(Base, PrefixerBase,
+                     Filter, Job, Station, Config, DataAvailability)
     # end of declare_tables()
+
+
+# These module objects only use the prefix defined in db.ini.
+# They should be re-defined if the prefix is to be changed.
+Base, PrefixerBase, Filter, Job, Station, Config, DataAvailability = declare_tables()

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -2,6 +2,7 @@ import traceback
 import logging
 import os
 import sys
+import sqlalchemy
 import time
 
 import click
@@ -932,6 +933,9 @@ try:
     db.close()
 except DBConfigNotFoundError:
     plugins = None
+except sqlalchemy.exc.OperationalError as e:
+    logging.critical('Unable to read project configuration: error connecting to the database:\n{}'.format(str(e)))
+    sys.exit(1)
 
 if plugins:
     plugins = plugins.split(",")

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -7,8 +7,10 @@ import time
 import click
 import pkg_resources
 
+from .. import DBConfigNotFoundError
+from ..api import connect, get_config, update_station
 from ..msnoise_table_def import DataAvailability
-from ..api import update_station
+
 
 
 @click.group()
@@ -925,12 +927,10 @@ cli.add_command(test)
 cli.add_command(plot)
 
 try:
-    from ..api import connect, get_config
-
     db = connect()
     plugins = get_config(db, "plugins")
     db.close()
-except:
+except DBConfigNotFoundError:
     plugins = None
 
 if plugins:
@@ -946,4 +946,7 @@ cli.add_command(p)
 
 
 def run():
-    cli(obj={})
+    try:
+        cli(obj={})
+    except DBConfigNotFoundError as e:
+        logging.critical(str(e))

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -7,7 +7,7 @@ import time
 import click
 import pkg_resources
 
-from ..msnoise_table_def import declare_tables
+from ..msnoise_table_def import DataAvailability
 from ..api import update_station
 
 
@@ -382,8 +382,6 @@ def populate(fromda):
     """Rapidly scan the archive filenames and find Network/Stations"""
     if fromda:
         logging.info("Overriding workflow...")
-        sqlschema = declare_tables()
-        DataAvailability = sqlschema.DataAvailability
         db = connect()
         stations = db.query(DataAvailability.net, DataAvailability.sta). \
             group_by(DataAvailability.net, DataAvailability.sta)


### PR DESCRIPTION
This PR is built on top of #124 (I will rebase it if necessary, only c5362d7 and c59cd07 are relevant here) and hopefully slightly improves error handling in the following cases:

 - if `db.ini` is missing, the code now cleanly throws an user exception and catches it in the appropriate locations, instead of using sys.exit() and masking all exceptions;

 - if the code cannot connect to the database specified in `db.ini`, it outputs a short error message explicitly showing the connection error, instead of outputting a chain of alarming tracebacks.

Resolves #128 