### PR TITLE
Feature/improve error handling

### DIFF
--- a/msnoise/__init__.py
+++ b/msnoise/__init__.py
@@ -7,3 +7,10 @@ __maintainer__ = "Thomas LECOCQ"
 __email__ = "Thomas.Lecocq at seismology.be"
 __status__ = "Production"
 
+
+class MSNoiseError(Exception):
+    pass
+
+
+class DBConfigNotFoundError(MSNoiseError):
+    pass

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -3,7 +3,6 @@ import datetime
 import itertools
 import logging
 import os
-import sys
 import glob
 import traceback
 try:
@@ -30,6 +29,7 @@ from obspy import read_inventory
 from obspy.io.xseed import Parser
 from obspy.geodetics import gps2dist_azimuth
 
+from . import DBConfigNotFoundError
 from .msnoise_table_def import Filter, Job, Station, Config, DataAvailability
 
 
@@ -130,11 +130,12 @@ def read_database_inifile(inifile=None):
 
     try:
         f = open(inifile, 'rb')
-    except FileNotFoundError:
-        print("No db.ini file in this directory, please run "
-                     "'msnoise db init' in this folder to initialize it as "
-                     "an MSNoise project folder.")
-        sys.exit(1)
+    #except FileNotFoundError:  # This is better but only for python3
+    except IOError:
+        raise DBConfigNotFoundError(
+                "No db.ini file in this directory, please run "
+                "'msnoise db init' in this folder to initialize it as "
+                "an MSNoise project folder.")
     try:
         # New ini file with prefix support
         tech, hostname, database, username, password, prefix = cPickle.load(f)

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -7,8 +7,10 @@ import time
 import click
 import pkg_resources
 
+from .. import DBConfigNotFoundError
+from ..api import connect, get_config, update_station
 from ..msnoise_table_def import DataAvailability
-from ..api import update_station
+
 
 
 @click.group()
@@ -937,12 +939,10 @@ def dtt(ctx, sta1, sta2, filterid, day, comp, mov_stack, show, outfile):
 ## Main script
 
 try:
-    from ..api import connect, get_config
-
     db = connect()
     plugins = get_config(db, "plugins")
     db.close()
-except:
+except DBConfigNotFoundError:
     plugins = None
 
 if plugins:
@@ -955,4 +955,7 @@ if plugins:
 
 
 def run():
-    cli(obj={})
+    try:
+        cli(obj={})
+    except DBConfigNotFoundError as e:
+        logging.critical(str(e))

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -2,6 +2,7 @@ import traceback
 import logging
 import os
 import sys
+import sqlalchemy
 import time
 
 import click
@@ -944,6 +945,9 @@ try:
     db.close()
 except DBConfigNotFoundError:
     plugins = None
+except sqlalchemy.exc.OperationalError as e:
+    logging.critical('Unable to read project configuration: error connecting to the database:\n{}'.format(str(e)))
+    sys.exit(1)
 
 if plugins:
     plugins = plugins.split(",")


### PR DESCRIPTION
This replaces PR #129 (which was based on the master branch and was also including commits from other PR).  The commits proposed here aim at improving error handling in the following cases:

- if `db.ini` is missing, the code now cleanly throws an user exception and catches it in the appropriate locations, instead of using sys.exit() and masking all exceptions;

- if the code cannot connect to the database specified in `db.ini`, it outputs a short error message explicitly showing the connection error, instead of outputting a chain of alarming tracebacks.
