### PR TITLE
Fix table prefix use in hard coded SQL statements

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import datetime
 import itertools
@@ -57,17 +58,6 @@ def get_logger(name, loglevel=None, with_pid=False):
     return logger
 
 
-def get_tech():
-    """Returns the current DB technology used (reads from the db.ini file)
-
-    :rtype: int
-    :returns: The database technology used: 1=sqlite 2=mysql
-    """
-    tech, hostname, database, username, password, prefix = \
-        read_database_inifile()
-    return tech
-
-
 def get_engine(inifile=None):
     """Returns the a SQLAlchemy Engine
 
@@ -78,17 +68,14 @@ def get_engine(inifile=None):
     :rtype: :class:`sqlalchemy.engine.Engine`
     :returns: An :class:`~sqlalchemy.engine.Engine` Object
     """
-    if not inifile:
-        inifile = os.path.join(os.getcwd(), 'db.ini')
-    tech, hostname, database, user, passwd, prefix = read_database_inifile(
-        inifile)
-    if tech == 1:
-        engine = create_engine('sqlite:///%s' % hostname, echo=False,
+    dbini = read_db_inifile(inifile)
+    if dbini.tech == 1:
+        engine = create_engine('sqlite:///%s' % dbini.hostname, echo=False,
                                connect_args={'check_same_thread': False})
     else:
-        engine = create_engine('mysql+pymysql://%s:%s@%s/%s' % (user, passwd,
-                                                                hostname,
-                                                                database),
+        engine = create_engine('mysql+pymysql://%s:%s@%s/%s'
+                               % (dbini.user, dbini.password,
+                                  dbini.hostname, dbini.database),
                                echo=False, poolclass=NullPool,
                                connect_args={'connect_timeout': 15})
     return engine
@@ -139,7 +126,7 @@ def create_database_inifile(tech, hostname, database, username, password,
     f.close()
 
 
-def read_database_inifile(inifile=None):
+def read_db_inifile(inifile=None):
     """Reads the parameters from the db.ini file.
 
     :type inifile: string
@@ -149,6 +136,8 @@ def read_database_inifile(inifile=None):
     :rtype: tuple
     :returns: tech, hostname, database, username, password
     """
+    IniFile = collections.namedtuple('IniFile', ['tech', 'hostname',
+        'database', 'username', 'password', 'prefix'])
     if not inifile:
         inifile = os.path.join(os.getcwd(), 'db.ini')
 
@@ -168,7 +157,7 @@ def read_database_inifile(inifile=None):
         tech, hostname, database, username, password = cPickle.load(f)
         prefix = ""
     f.close()
-    return [tech, hostname, database, username, password, prefix]
+    return IniFile(tech, hostname, database, username, password, prefix)
 
 
 # CONFIG
@@ -914,7 +903,7 @@ def get_dtt_next_job(session, flag='T', jobtype='DTT'):
         Days of the next DTT jobs -
         Job IDs (for later being able to update their flag).
     """
-    if get_tech() == 1:
+    if read_db_inifile().tech == 1:
         rand = func.random
     else:
         rand = func.rand

--- a/msnoise/msnoise_admin.py
+++ b/msnoise/msnoise_admin.py
@@ -700,14 +700,16 @@ def main(port=5000):
     else:
         admin.name = "MSNoise"
     admin.project_folder = os.getcwd()
-    tech, hostname, database, username, password, prefix = \
-        read_database_inifile()
-    if prefix != "":
-        prefix = "/%s_*" % prefix
-    if tech == 1:
-        database = "SQLite: %s%s" % (hostname, prefix)
+    dbini = read_db_inifile()
+    if dbini.prefix != "":
+        prefix = "/%s_*" % dbini.prefix
     else:
-        database = "MySQL: %s@%s:%s%s" % (username, hostname, database, prefix)
+        prefix = ""
+    if dbini.tech == 1:
+        database = "SQLite: %s%s" % (dbini.hostname, prefix)
+    else:
+        database = "MySQL: %s@%s:%s%s" % (dbini.username, dbini.hostname,
+                                          dbini.database, prefix)
     admin.project_database = database
 
     jobtypes = ["CC", "STACK", "MWCS", "DTT"]

--- a/msnoise/s01scan_archive.py
+++ b/msnoise/s01scan_archive.py
@@ -502,7 +502,7 @@ def main(init=False, threads=1, crondays=None, forced_path=None,
     logger.info('*** Starting: Scan Archive ***')
     db = api.connect()
 
-    if api.get_tech() == 1 and threads != 1:
+    if api.read_db_inifile().tech == 1 and threads != 1:
         logger.warning('You can not work on %i threads because SQLite only'
                        ' supports 1 connection at a time. Continuing with '
                        ' 1 process only.' % threads)


### PR DESCRIPTION
Functions 'clean_duplicates', 'new_jobs', or 'compute_cc2' did not take
into account the table prefix defined in the `db.ini` file in the SQL
statements passed to the sqlalechemy session.execute() function.

This fixes this issue, while also getting ride of the api.get_tech()
function and changing the api.read_database_inifile() into a
api.read_db_inifile() that returns a more convenient
collections.namedtuple object that generalise and replace get_tech().

This should fix #143 