### PR TITLE
Solve error from latest scipy version

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -26,7 +26,7 @@ import pandas as pd
 import scipy as sp
 import scipy.fftpack
 from scipy.fftpack.helper import next_fast_len
-import scipy.fftpack._fftpack as sff
+#import scipy.fftpack._fftpack as sff
 import scipy.optimize
 
 from obspy.core import Stream, Trace, read, AttribDict, UTCDateTime
@@ -1655,7 +1655,7 @@ def check_and_phase_shift(trace, taper_length=20.0):
         trace.data = np.real(FFTdata[:len(trace.data)]).astype(np.float)
         trace.stats.starttime += dt
         del FFTdata, fftfreq
-        clean_scipy_cache()
+        #clean_scipy_cache()
         return trace
     else:
         return trace


### PR DESCRIPTION
The scipy.fftpack._fftpack module doesn't exist in scipy version > 0.14.1
File "/home/sysadmin/anaconda3/envs/msnoise/lib/python3.6/site-packages/msnoise/api.py", line 29, in <module> import scipy.fftpack._fftpack as sff ModuleNotFoundError: No module named 'scipy.fftpack._fftpack'