### PR TITLE
Mwcs time axis fix (for non-integer values of step*df)

### DIFF
--- a/msnoise/move2obspy.py
+++ b/msnoise/move2obspy.py
@@ -419,6 +419,7 @@ segment.
     time_axis = []
 
     window_length_samples = np.int(window_length * df)
+    step_samples = int(step * df)
     # try:
     #     from sf.helper import next_fast_len
     # except ImportError:
@@ -439,8 +440,8 @@ segment.
         cri = scipy.signal.detrend(cri, type='linear')
         cri *= tp
 
-        minind += int(step * df)
-        maxind += int(step * df)
+        minind += step_samples
+        maxind += step_samples
 
         fcur = sf.fft(cci, n=padd)[:padd // 2]
         fref = sf.fft(cri, n=padd)[:padd // 2]
@@ -502,7 +503,7 @@ segment.
 
         delta_err.append(e)
         delta_mcoh.append(np.real(mcoh))
-        time_axis.append(tmin + window_length / 2. + count * step)
+        time_axis.append(tmin + window_length / 2. + count * (step_samples/df))
         count += 1
 
         del fcur, fref

--- a/msnoise/stretch.py
+++ b/msnoise/stretch.py
@@ -105,6 +105,8 @@ def main():
         ref_name = pair.replace(':', '_')
         station1, station2 = pair.split(":")
 
+        s1 = get_station(db, station1.split('.')[0], station1.split('.')[1])
+        s2 = get_station(db, station2.split('.')[0], station2.split('.')[1])
 
         dtt_lag = get_config(db, "dtt_lag")
         dtt_v = float(get_config(db, "dtt_v"))
@@ -115,7 +117,7 @@ def main():
         if dtt_lag == "static":
             minlag = dtt_minlag
         else:
-            minlag = get_interstation_distance(station1, station2, station1.coordinates) / dtt_v
+            minlag = get_interstation_distance(s1, s2, s1.coordinates) / dtt_v
 
         maxlag2 = minlag + dtt_width
         print("betweeen", minlag, "and", maxlag2)


### PR DESCRIPTION
Fix for incorrect time axis output when the mwcs step size multiplied by sampling freq (i.e. step * df) is not an integer, following issue #252.

Below is the same output i produced in the raised issue, using the modified mwcs() function. Can see it is now not showing a shift at small window sizes.

![image](https://user-images.githubusercontent.com/50132148/149795512-6cf3f36f-15c7-42d5-a570-996455e540c9.png)
