### PR TITLE
Fix to AC temp normalization (previously not applied under certain conditions)

### DIFF
--- a/msnoise/move2obspy.py
+++ b/msnoise/move2obspy.py
@@ -419,6 +419,7 @@ segment.
     time_axis = []
 
     window_length_samples = np.int(window_length * df)
+    step_samples = int(step * df)
     # try:
     #     from sf.helper import next_fast_len
     # except ImportError:
@@ -439,8 +440,8 @@ segment.
         cri = scipy.signal.detrend(cri, type='linear')
         cri *= tp
 
-        minind += int(step * df)
-        maxind += int(step * df)
+        minind += step_samples
+        maxind += step_samples
 
         fcur = sf.fft(cci, n=padd)[:padd // 2]
         fref = sf.fft(cri, n=padd)[:padd // 2]
@@ -502,7 +503,7 @@ segment.
 
         delta_err.append(e)
         delta_mcoh.append(np.real(mcoh))
-        time_axis.append(tmin + window_length / 2. + count * step)
+        time_axis.append(tmin + window_length / 2. + count * (step_samples/df))
         count += 1
 
         del fcur, fref

--- a/msnoise/s03compute_no_rotation.py
+++ b/msnoise/s03compute_no_rotation.py
@@ -487,7 +487,6 @@ def main(loglevel="INFO"):
                                             df=params.goal_sampling_rate,
                                             corners=8)                        
 
-
                 # First let's compute the AC and SC
                 if len(single_station_pair_index_ac):
                     tmp = _data.copy()

--- a/msnoise/s03compute_no_rotation.py
+++ b/msnoise/s03compute_no_rotation.py
@@ -485,11 +485,7 @@ def main(loglevel="INFO"):
                         _data[i] = bandpass(_, freqmin=filterlow,
                                             freqmax=filterhigh,
                                             df=params.goal_sampling_rate,
-                                            corners=8)
-                        if params.clip_after_whiten:
-                            logger.debug("Winsorizing (clipping) data after bandpass (AC)")
-                            _data[i] = winsorizing(_data[i], params, input="timeseries")
-
+                                            corners=8)                        
 
 
                 # First let's compute the AC and SC
@@ -503,9 +499,9 @@ def main(loglevel="INFO"):
                                               freqmax=filterhigh,
                                               df=params.goal_sampling_rate,
                                               corners=8)
-                            if params.clip_after_whiten:
-                                logger.debug("Winsorizing (clipping) data after bandpass (AC)")
-                                tmp[i] = winsorizing(tmp[i], params, input="timeseries")
+                    if params.clip_after_whiten:
+                        logger.debug("Winsorizing (clipping) data after bandpass (AC)")
+                        tmp = winsorizing(tmp, params, input="timeseries")
 
 
                     if params.cc_type_single_station_AC == "CC":

--- a/msnoise/s03compute_no_rotation.py
+++ b/msnoise/s03compute_no_rotation.py
@@ -485,7 +485,7 @@ def main(loglevel="INFO"):
                         _data[i] = bandpass(_, freqmin=filterlow,
                                             freqmax=filterhigh,
                                             df=params.goal_sampling_rate,
-                                            corners=8)                        
+                                            corners=8)
 
                 # First let's compute the AC and SC
                 if len(single_station_pair_index_ac):

--- a/msnoise/s03compute_no_rotation.py
+++ b/msnoise/s03compute_no_rotation.py
@@ -486,6 +486,11 @@ def main(loglevel="INFO"):
                                             freqmax=filterhigh,
                                             df=params.goal_sampling_rate,
                                             corners=8)
+                        if params.clip_after_whiten:
+                            logger.debug("Winsorizing (clipping) data after bandpass (AC)")
+                            _data[i] = winsorizing(_data[i], params, input="timeseries")
+
+
 
                 # First let's compute the AC and SC
                 if len(single_station_pair_index_ac):

--- a/msnoise/stretch.py
+++ b/msnoise/stretch.py
@@ -105,6 +105,8 @@ def main():
         ref_name = pair.replace(':', '_')
         station1, station2 = pair.split(":")
 
+        s1 = get_station(db, station1.split('.')[0], station1.split('.')[1])
+        s2 = get_station(db, station2.split('.')[0], station2.split('.')[1])
 
         dtt_lag = get_config(db, "dtt_lag")
         dtt_v = float(get_config(db, "dtt_v"))
@@ -115,7 +117,7 @@ def main():
         if dtt_lag == "static":
             minlag = dtt_minlag
         else:
-            minlag = get_interstation_distance(station1, station2, station1.coordinates) / dtt_v
+            minlag = get_interstation_distance(s1, s2, s1.coordinates) / dtt_v
 
         maxlag2 = minlag + dtt_width
         print("betweeen", minlag, "and", maxlag2)


### PR DESCRIPTION
Seems temp normalization wasn't been applied to ACs if params.whitening=='N' and params.clip_after_whiten=='Y', hence the differences observed in Issue #257 when comparing ACs with whitening=='N' and whitening=='A' (which should have produced the same waveform if whitening of ACs is skipped in both cases). 

Reason is because the conditional statement 
```
if params.clip_after_whiten:
     logger.debug("Winsorizing (clipping) data after bandpass (AC)")
     tmp = winsorizing(tmp, params, input="timeseries")
```
was only within the block of code following '**if params.whitening == "A"**' for the auto-correlations. Have now moved this outside of this block of code so that it will always be checked for ACs regardless of params.whitening value (as with SC and CC blocks). 

I guess, if you're setting params.whitening == 'N', then it would make sense to have params.clip_after_whiten == 'N' (which would give desired behaviour)... but not obvious that this would be a necessary, at least wasn't to me! 