### PR TITLE
tidied error outputs

### DIFF
--- a/msnoise/move2obspy.py
+++ b/msnoise/move2obspy.py
@@ -414,6 +414,7 @@ segment.
     time_axis = []
 
     window_length_samples = int(window_length * df)
+    step_samples = int(step * df)
     # try:
     #     from sf.helper import next_fast_len
     # except ImportError:
@@ -434,8 +435,8 @@ segment.
         cri = scipy.signal.detrend(cri, type='linear')
         cri *= tp
 
-        minind += int(step * df)
-        maxind += int(step * df)
+        minind += step_samples
+        maxind += step_samples
 
         fcur = sf.fft(cci, n=padd)[:padd // 2]
         fref = sf.fft(cri, n=padd)[:padd // 2]
@@ -497,7 +498,7 @@ segment.
 
         delta_err.append(e)
         delta_mcoh.append(np.real(mcoh))
-        time_axis.append(tmin + window_length / 2. + count * step)
+        time_axis.append(tmin + window_length / 2. + count * (step_samples/df))
         count += 1
 
         del fcur, fref

--- a/msnoise/s04_stack2.py
+++ b/msnoise/s04_stack2.py
@@ -147,10 +147,13 @@ def main(stype, interval=1.0, loglevel="INFO"):
         sta1, sta2 = pair.split(':')
         for f in filters:
             filterid = int(f.ref)
-            for components in params.all_components:
-                pair = "%s:%s" % (sta1, sta2)
-                sta1 = sta1
-                sta2 = sta2
+
+            if sta1 == sta2:
+                components_to_compute = params.components_to_compute_single_station
+            else:
+                components_to_compute = params.components_to_compute
+
+            for components in components_to_compute:
                 logger.info('Processing %s-%s-%i' %
                       (pair, components, filterid))
 

--- a/msnoise/s05compute_mwcs2.py
+++ b/msnoise/s05compute_mwcs2.py
@@ -163,10 +163,16 @@ def main(loglevel="INFO"):
                 n = next_fast_len(len(a))
                 return whiten(a, n, 1./params.cc_sampling_rate,
                               low, high, returntime=True)
-            for components in params.all_components:
-                ref_name = pair.replace(':', '_')
-                station1, station2 = pair.split(":")
+            ref_name = pair.replace(':', '_')
+            station1, station2 = pair.split(":")
+            
+            if station1 == station2:
+                components_to_compute = params.components_to_compute_single_station
+            else:
+                components_to_compute = params.components_to_compute
 
+
+            for components in components_to_compute:
                 try:
                     ref = xr_get_ref(station1, station2, components, filterid, taxis)
                     ref = ref.CCF.values

--- a/msnoise/s06compute_dtt2.py
+++ b/msnoise/s06compute_dtt2.py
@@ -67,7 +67,12 @@ def main(interval=1, loglevel="INFO"):
             filterid = int(f.ref)
             freqmin = f.mwcs_low
             freqmax = f.mwcs_high
-            for components in params.all_components:
+            if station1 == station2:
+                components_to_compute = params.components_to_compute_single_station
+            else:
+                components_to_compute = params.components_to_compute
+
+            for components in components_to_compute:
                 for mov_stack in mov_stacks:
                     output = []
                     try:

--- a/msnoise/s07_compute_dvv.py
+++ b/msnoise/s07_compute_dvv.py
@@ -42,6 +42,8 @@ def main(interval=1, loglevel="INFO"):
                 continue
             xr_save_dvv("ALL", filterid, mov_stack, dvv)
             del dvv
+    
+    logger.info('*** Finished: Compute DV/V ***')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stopping errors being output during processing of new codes (e.g. stack2, mwcs2, dtt2, dvv) when msnoise is functioning as intended, as makes it confusing (gives impression not working) 

Largely, just stopped using params.all_components in the loops as this throws an error when files don't exist (e.g. for pairs and components combinations that were never intended to be processed). Correction in api.py, compute_dvv function a bit messy, prob cleaner way to do it.

Also was an error being output in api.py, xr_save_dvv function when only one pair for given components (with dataframe.stack().stack() then throwing an error). Now fixed.

Fixes Issue #320