### PR TITLE
movstack single tuple bugfix

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -293,7 +293,7 @@ def get_params(session):
     params.all_components = np.unique(params.components_to_compute_single_station + \
                             params.components_to_compute)
 
-    if params.mov_stack.count(',') == 1:
+    if not isinstance(params.mov_stack[0],tuple):
         params.mov_stack = [params.mov_stack, ]
     else:
         params.mov_stack = params.mov_stack

--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -293,7 +293,7 @@ def get_params(session):
     params.all_components = np.unique(params.components_to_compute_single_station + \
                             params.components_to_compute)
 
-    if not isinstance(params.mov_stack[0],tuple):
+    if not isinstance(params.mov_stack[0], tuple):
         params.mov_stack = [params.mov_stack, ]
     else:
         params.mov_stack = params.mov_stack


### PR DESCRIPTION
PROBLEM:

Previously, when single tuple defined in list of tuples for mov_stacks, treated as single tuple e.g. (('1d','1d')) becomes ('1d','1d'), so 

```
for mov_stack in mov_stacks:
                    mov_rolling, mov_sample = mov_stack
```

gives mov_rolling as '1' and mov_sample as 'd'. So conditional statement (if mov_rolling == mov_sample) not satisfied.

Similarly, error returned if len(mov_stack) > 2 in case of single tuple (e.g. if (('5min','30s')), mov_stack = '5min' and tries to unpack this into two variables).

FIX:

Checks to see if mov_stacks contains only single tuple, if so...wraps in another tuple. Now functions correctly