### PR TITLE
Much faster stretching

### DIFF
--- a/msnoise/stretch2.py
+++ b/msnoise/stretch2.py
@@ -321,4 +321,4 @@ def main(loglevel="INFO"):
         if not params.hpc:
             for job in jobs:
                 update_job(db, job.day, job.pair, 'DTT', 'T')
-    logger.info('*** Finished: Compute MWCS ***')
+    logger.info('*** Finished: Compute Stretching ***')

--- a/msnoise/stretch2.py
+++ b/msnoise/stretch2.py
@@ -137,7 +137,7 @@ def main(loglevel="INFO"):
     # Reconfigure logger to show the pid number in log records
     logger = get_logger('msnoise.compute_mwcs_child', loglevel,
                         with_pid=True)
-    logger.info('*** Starting: Compute MWCS ***')
+    logger.info('*** Starting: Compute Stretching ***')
 
     db = connect()
     params = get_params(db)


### PR DESCRIPTION
Removed the loops through each day, and through each stretched version of reference.

Compared old and new codes on a few hours of data, single pair and filter, with 10 second sampling interval for dv/v results.

Old code took 2 minutes 30 seconds.
New code took less than 10 seconds.

So more than 20x faster.

Also verified that outputs match exactly:

![image](https://github.com/ROBelgium/MSNoise/assets/50132148/5463a217-685e-4e76-81d9-3c268bd2f9d0)

