### PR TITLE
fix: temp norm applied for AC and whitening != A

### DIFF
--- a/msnoise/s03compute_no_rotation.py
+++ b/msnoise/s03compute_no_rotation.py
@@ -508,9 +508,9 @@ def main(loglevel="INFO"):
                                               freqmax=filterhigh,
                                               df=params.goal_sampling_rate,
                                               corners=8)
-                            if params.clip_after_whiten:
-                                # logger.debug("Winsorizing (clipping) data after bandpass (AC)")
-                                tmp[i] = winsorizing(tmp[i], params, input="timeseries")
+                    if params.clip_after_whiten:
+                        # logger.debug("Winsorizing (clipping) data after bandpass (AC)")
+                        tmp = winsorizing(tmp, params, input="timeseries")
 
 
                     if params.cc_type_single_station_AC == "CC":


### PR DESCRIPTION
Temp normalization wasn't previously applied to ACs if params.whitening=='N' and params.clip_after_whiten=='Y', hence the differences observed in Issue https://github.com/ROBelgium/MSNoise/issues/257 when comparing ACs with whitening=='N' and whitening=='A' (which should have produced the same waveform if whitening of ACs is skipped in both cases).

Reason is because the conditional statement

if params.clip_after_whiten:
     logger.debug("Winsorizing (clipping) data after bandpass (AC)")
     tmp = winsorizing(tmp, params, input="timeseries")

was only within the block of code following 'if params.whitening == "A"' for the auto-correlations. Have now moved this outside of this block of code so that it will always be checked for ACs regardless of params.whitening value (as with SC and CC blocks).

I guess, if you're setting params.whitening == 'N', then it would make sense to have params.clip_after_whiten == 'N' (which would give desired behaviour)... but not obvious that this would be a necessary, at least wasn't to me!