### PR TITLE
Update s04_stack2.py when keep_all is False

### DIFF
--- a/msnoise/s04_stack2.py
+++ b/msnoise/s04_stack2.py
@@ -156,7 +156,10 @@ def main(stype, interval=1.0, loglevel="INFO"):
             for components in components_to_compute:
                 logger.info('Processing %s-%s-%i' %
                       (pair, components, filterid))
-                c = get_results_all(db, sta1, sta2, filterid, components, days, format="xarray")
+                if params.keep_all:
+                    c = get_results_all(db, sta1, sta2, filterid, components, days, format="xarray")
+                else:
+                    c = get_results(db, sta1, sta2, filterid, components, days,  mov_stack=1, format="xarray", params=params)
                 # print(c)
                 # dr = xr_save_ccf(sta1, sta2, components, filterid, 1, taxis, c)
                 dr = c


### PR DESCRIPTION
Hello :)
modified to use get_results() when keep_all=False as there is no output_folder (CROSS_CRORRELATIONS) for get_results_all() consequently no REF folder were created (empty dataframes)
However, not sure mov_stack=1 can be hard-coded ... 