### PR TITLE
get_results() when keep_all=False in s04_stack2.py

### DIFF
--- a/msnoise/s04_stack2.py
+++ b/msnoise/s04_stack2.py
@@ -159,7 +159,7 @@ def main(stype, interval=1.0, loglevel="INFO"):
                 if params.keep_all:
                     c = get_results_all(db, sta1, sta2, filterid, components, days, format="xarray")
                 else:
-                    logger.warning("keep_all=N used by default mov_stack=("1D","1D")") 
+                    logger.warning("keep_all=N used by default mov_stack=('1D','1D')") 
                     c = get_results(db, sta1, sta2, filterid, components, days,  mov_stack=1, format="xarray", params=params)
                 # print(c)
                 # dr = xr_save_ccf(sta1, sta2, components, filterid, 1, taxis, c)


### PR DESCRIPTION
modified to use ```get_results()``` when ```keep_all=False``` as there is no output_folder (CROSS_CRORRELATIONS) for ```get_results_all()``` consequently no REF folder were created (empty dataframes)

+line 159-163 conditional ```get_results_all()``` based on ```keep_all```. If ```keep_all=False```, it shows a warning message and uses ```get_result()```.
+line 177 to correct ```ValueError: index must be monotonic for resampling``` due to the first modification