### PR TITLE
Jobs in date range

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -2649,3 +2649,7 @@ def xr_save_wct(station1, station2, components, filterid, mov_stack, taxis, dvv_
     logging.debug(f"Saved WCT data to {fn}")
     # Clean up
     del dvv_da, err_da, coh_da, ds
+
+def filter_within_daterange(date, start_date, end_date):
+    """Check if a date falls within the configured range"""
+    return start_date <= date <= end_date

--- a/msnoise/s02new_jobs.py
+++ b/msnoise/s02new_jobs.py
@@ -95,8 +95,7 @@ def main(init=False, nocc=False):
     updated_days = []
     nfs = get_new_files(db)
     now = datetime.datetime.utcnow()
-    start_date = datetime.datetime.strptime(get_config(db, 'startdate'), '%Y-%m-%d').date()
-    end_date = datetime.datetime.strptime(get_config(db, 'enddate'), '%Y-%m-%d').date()
+    start_date, end_date, datelist = build_movstack_datelist(db)
     
     for nf in nfs:
         tmp = "%s.%s.%s" % (nf.net, nf.sta, nf.loc)

--- a/msnoise/s02new_jobs.py
+++ b/msnoise/s02new_jobs.py
@@ -1,6 +1,8 @@
 """ This script searches the database for files flagged "N"ew or "M"odified.
 For each date in the configured range, it checks if other stations are
-available and defines the new jobs to be processed. Those are inserted in the
+available and defines the new jobs to be processed.  Only jobs within the 
+configured ``startdate`` and ``enddate`` are considered avoiding unnecessary 
+job creation. Those are inserted in the
 *jobs* table of the database.
 
 To run it from the console:

--- a/msnoise/s02new_jobs.py
+++ b/msnoise/s02new_jobs.py
@@ -93,6 +93,9 @@ def main(init=False, nocc=False):
     updated_days = []
     nfs = get_new_files(db)
     now = datetime.datetime.utcnow()
+    start_date = datetime.datetime.strptime(get_config(db, 'startdate'), '%Y-%m-%d').date()
+    end_date = datetime.datetime.strptime(get_config(db, 'enddate'), '%Y-%m-%d').date()
+    
     for nf in nfs:
         tmp = "%s.%s.%s" % (nf.net, nf.sta, nf.loc)
         if tmp not in stations_to_analyse:
@@ -100,16 +103,17 @@ def main(init=False, nocc=False):
 
         start, end = nf.starttime.date(), nf.endtime.date()
         for date in pd.date_range(start, end, freq="D"):
-            updated_days.append(date.date())
-            for jobtype in extra_jobtypes_new_files:
-                job = {"day": date.date().strftime("%Y-%m-%d"),
-                                 "pair": "%s.%s.%s" % (nf.net, nf.sta, nf.loc),
-                                 "jobtype": jobtype,
-                                 "flag": "T", "lastmod": now}
-                jobtxt = ''.join(str(x) for x in job.values())
-                if jobtxt not in crap_all_jobs_text:
-                    all_jobs.append(job)
-                    crap_all_jobs_text.append(jobtxt)
+            if filter_within_daterange(date.date(), start_date, end_date):
+                updated_days.append(date.date())
+                for jobtype in extra_jobtypes_new_files:
+                    job = {"day": date.date().strftime("%Y-%m-%d"),
+                                     "pair": "%s.%s.%s" % (nf.net, nf.sta, nf.loc),
+                                     "jobtype": jobtype,
+                                     "flag": "T", "lastmod": now}
+                    jobtxt = ''.join(str(x) for x in job.values())
+                    if jobtxt not in crap_all_jobs_text:
+                        all_jobs.append(job)
+                        crap_all_jobs_text.append(jobtxt)
 
     # all_jobs = pd.DataFrame(all_jobs)
     # all_jobs.drop_duplicates(inplace=True)


### PR DESCRIPTION
Add ```filter_within_daterange``` function in api and conditional date filter to  s02new_jobs.py. 
Thus it only adds jobs within the defined date range (within ```startdate``` and ```enddate``` from config), so it doesn't process the 20 years of data available if I want to process 1 year.