### PR TITLE
Check for NaN stack data and update WCT jobs to "T"

### DIFF
--- a/msnoise/s04_stack2.py
+++ b/msnoise/s04_stack2.py
@@ -92,7 +92,7 @@ Configuration Parameters
 
 
 Once done, each job is marked "D"one in the database and, unless ``hpc`` is
-``Y``, MWCS jobs are inserted/updated in the database.
+``Y``, MWCS and WCT jobs are inserted/updated in the database.
 
 Usage:
 ~~~~~~
@@ -385,3 +385,4 @@ def main(stype, interval=1.0, loglevel="INFO"):
             if stype != "step" and not params.hpc:
                 for job in jobs:
                     update_job(db, job.day, job.pair, 'MWCS', 'T')
+                    update_job(db, job.day, job.pair, 'WCT', 'T')

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -443,9 +443,7 @@ def test_031_instrument_response(setup_environment):
 @pytest.mark.order(32)
 def test_032_wct():
     from ..s08compute_wct import main as compute_wct_main
-    db = connect()
     compute_wct_main()
-    db.close()
   
 @pytest.mark.order(33)
 def test_033_validate_stack_data():

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -444,14 +444,6 @@ def test_031_instrument_response(setup_environment):
 def test_032_wct():
     from ..s08compute_wct import main as compute_wct_main
     db = connect()
-    dbini = read_db_inifile()
-    prefix = (dbini.prefix + '_') if dbini.prefix != '' else ''
-    db.execute(text(
-        f"INSERT INTO {prefix}jobs (pair, day, jobtype, flag) "
-        f"SELECT pair, day, 'WCT', 'T' FROM {prefix}jobs "
-        f"WHERE jobtype='STACK' AND flag='D';"
-    ))
-    db.commit()
     compute_wct_main()
     db.close()
 

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -513,27 +513,26 @@ def test_034_stack_validation_handling():
     # Setup test data
     times = pd.date_range('2020-01-01', periods=10)
     taxis = np.linspace(-50, 50, 100)
-    
-    # Error case (Invalid data)
-    ds = xr.Dataset()  
     sta1, sta2 = "NET1.STA1", "NET2.STA2"
     components = "ZZ"
     filterid = 1
     
+    # Test invalid data path
+    ds = xr.Dataset()
     is_valid, message = validate_stack_data(ds, "reference")
-    if not is_valid:
-        # Just execute the code path
-        logger.error(f"Invalid reference data for {sta1}:{sta2}-{components}-{filterid}: {message}")
+    assert not is_valid
+    logger.error(f"Invalid reference data for {sta1}:{sta2}-{components}-{filterid}: {message}")
     
-    # Warning case (partial NaN values)
+    # Test warning path
     data = np.random.random((len(times), len(taxis)))
     data[0:5, :] = np.nan  # Make 50% of data NaN
     da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
     ds = da.to_dataset(name='CCF')
     
     is_valid, message = validate_stack_data(ds, "reference")
-    if "Warning" in message:
-        logger.warning(f"{sta1}:{sta2}-{components}-{filterid}: {message}")
+    assert is_valid
+    assert "Warning" in message
+    logger.warning(f"{sta1}:{sta2}-{components}-{filterid}: {message}")
 
 @pytest.mark.order(100)
 def test_100_plot_interferogram():

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -447,6 +447,62 @@ def test_032_wct():
     compute_wct_main()
     db.close()
 
+@pytest.mark.order(33)  # Add appropriate order number
+def test_033_validate_stack_data():
+    from ..api import validate_stack_data
+    import xarray as xr
+    import numpy as np
+    import pandas as pd
+    
+    # Test empty dataset
+    ds = xr.Dataset()
+    is_valid, message = validate_stack_data(ds, "reference")
+    assert not is_valid
+    assert "No data found for reference stack" in message
+
+    # Test dataset without CCF
+    ds = xr.Dataset({"wrong_var": 1})
+    is_valid, message = validate_stack_data(ds, "reference") 
+    assert not is_valid
+    assert "Missing CCF data in reference stack" in message
+
+    # Test empty CCF data
+    times = pd.date_range('2020-01-01', periods=0)
+    taxis = np.linspace(-50, 50, 100)
+    data = np.random.random((0, len(taxis)))
+    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+    ds = da.to_dataset(name='CCF')
+    is_valid, message = validate_stack_data(ds, "reference")
+    assert not is_valid 
+    assert "Empty dataset in reference stack" in message
+
+    # Test all NaN values
+    times = pd.date_range('2020-01-01', periods=10)
+    data = np.full((len(times), len(taxis)), np.nan)
+    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+    ds = da.to_dataset(name='CCF')
+    is_valid, message = validate_stack_data(ds, "reference")
+    assert not is_valid
+    assert "Reference stack contains only NaN values" in message
+
+    # Test partial NaN values
+    data = np.random.random((len(times), len(taxis)))
+    data[0:5, :] = np.nan
+    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+    ds = da.to_dataset(name='CCF')
+    is_valid, message = validate_stack_data(ds, "reference")
+    assert is_valid
+    assert "Warning: Reference stack contains" in message
+    assert "50.0% NaN values" in message
+
+    # Test valid data
+    data = np.random.random((len(times), len(taxis)))
+    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+    ds = da.to_dataset(name='CCF')
+    is_valid, message = validate_stack_data(ds, "reference")
+    assert is_valid
+    assert message == "OK"
+  
 @pytest.mark.order(100)
 def test_100_plot_cctfime():
     from ..plots.ccftime import main as ccftime_main

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -505,49 +505,33 @@ def test_033_validate_stack_data():
     
 @pytest.mark.order(34)
 def test_034_stack_validation_handling():
-    from ..api import connect, update_config, validate_stack_data, get_config
+    from ..api import validate_stack_data
     import xarray as xr
     import numpy as np
     import pandas as pd
     
-    # Setup database
-    db = connect()
+    # Prepare test data 
+    sta1, sta2 = "STA1", "STA2"
+    components = "ZZ"
+    filterid = 1
     
-    # Store original config values
-    original_configs = {
-        'ref_begin': get_config(db, 'ref_begin'),
-        'ref_end': get_config(db, 'ref_end'),
-        'startdate': get_config(db, 'startdate'),
-        'enddate': get_config(db, 'enddate'),
-        'mov_stack': get_config(db, 'mov_stack')
-    }
+    # Create empty dataset trigger the error log
+    ds = xr.Dataset()
+    is_valid, message = validate_stack_data(ds, "reference")
+    if not is_valid:
+        logger.error(f"Invalid reference data for {sta1}:{sta2}-{components}-{filterid}: {message}")
     
-    try:
-        # Test direct validation function
-        # Create empty dataset for error path
-        ds = xr.Dataset()
-        is_valid, message = validate_stack_data(ds, "reference") 
-        assert not is_valid
-        assert "No data found for reference stack" in message
-        
-        # Create dataset with NaNs for warning path
-        times = pd.date_range('2020-01-01', periods=10)
-        taxis = np.linspace(-50, 50, 100)
-        data = np.random.random((len(times), len(taxis)))
-        data[0:5, :] = np.nan  # Add NaNs to trigger warning
-        da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
-        ds = da.to_dataset(name='CCF')
-        
-        is_valid, message = validate_stack_data(ds, "reference")
-        assert is_valid
-        assert "Warning" in message
-        
-    finally:
-        # Restore original config values
-        for key, value in original_configs.items():
-            update_config(db, key, value)
-        
-        db.close()
+    # Create dataset with some NaN values - trigger the warning log
+    times = pd.date_range('2020-01-01', periods=10)
+    taxis = np.linspace(-50, 50, 100)
+    data = np.random.random((len(times), len(taxis)))
+    data[0:5, :] = np.nan
+    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+    ds = da.to_dataset(name='CCF')
+    
+    is_valid, message = validate_stack_data(ds, "reference")
+    if "Warning" in message:
+        logger.warning(f"{sta1}:{sta2}-{components}-{filterid}: {message}")
                   
 @pytest.mark.order(100)
 def test_100_plot_interferogram():

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -510,30 +510,38 @@ def test_034_stack_validation_handling():
     import numpy as np
     import pandas as pd
     
-    # Setup test data
+    # Create minimal test data
     times = pd.date_range('2020-01-01', periods=10)
     taxis = np.linspace(-50, 50, 100)
-    sta1, sta2 = "NET1.STA1", "NET2.STA2"
-    components = "ZZ"
-    filterid = 1
     
-    # Test invalid data path
-    ds = xr.Dataset()
-    is_valid, message = validate_stack_data(ds, "reference")
-    assert not is_valid
-    logger.error(f"Invalid reference data for {sta1}:{sta2}-{components}-{filterid}: {message}")
+    # Test with actual code's variables and logic
+    pairs = [('STA1', 'STA2'), ('STA3', 'STA3')]
+    filters = [type('Filter', (), {'ref': '1'})]
+    components = 'ZZ'
     
-    # Test warning path
-    data = np.random.random((len(times), len(taxis)))
-    data[0:5, :] = np.nan  # Make 50% of data NaN
-    da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
-    ds = da.to_dataset(name='CCF')
-    
-    is_valid, message = validate_stack_data(ds, "reference")
-    assert is_valid
-    assert "Warning" in message
-    logger.warning(f"{sta1}:{sta2}-{components}-{filterid}: {message}")
-
+    for sta1, sta2 in pairs:
+        for f in filters:
+            filterid = int(f.ref)
+            
+            # Create test datasets that will trigger our paths
+            if sta1 == 'STA1':
+                # Test error path with empty dataset
+                c = xr.Dataset()
+                is_valid, message = validate_stack_data(c, "reference")
+                if not is_valid:
+                    logger.error(f"Invalid reference data for {sta1}:{sta2}-{components}-{filterid}: {message}")
+                    continue
+            else:
+                # Test warning path with partial NaN data
+                data = np.random.random((len(times), len(taxis)))
+                data[0:5, :] = np.nan
+                da = xr.DataArray(data, coords=[times, taxis], dims=['times', 'taxis'])
+                c = da.to_dataset(name='CCF')
+                
+                is_valid, message = validate_stack_data(c, "reference")
+                if "Warning" in message:
+                    logger.warning(f"{sta1}:{sta2}-{components}-{filterid}: {message}")
+                  
 @pytest.mark.order(100)
 def test_100_plot_interferogram():
     db = connect()


### PR DESCRIPTION
1) Adds validation on reference and moving stacks to prevent processing empty datasets or those containing only NaN values. Previously, no error was shown when processing reference stacks full of NaN values. When issues are found, appropriate error messages guide users to potential data problems:
- Checks for missing data, empty datasets, and NaN content before processing
- Distinct error messages for reference vs moving stacks
- Validation occurs before wiener filtering to avoid unnecessary processing

Added a brief docstring update to document this validation step.

2) Adds WCT job updates after MWCS in the stack processing

I can submit each part separately if needed.