### PR TITLE
dtt params to filter table + general config updates

### DIFF
--- a/msnoise/api.py
+++ b/msnoise/api.py
@@ -324,7 +324,7 @@ def get_filters(session, all=False, ref=None):
 
 
 def update_filter(session, ref, low, mwcs_low, high, mwcs_high,
-                  mwcs_wlen, mwcs_step, used):
+                  mwcs_wlen, mwcs_step, dtt_minlag, dtt_width, dtt_v, used):
     """Updates or Insert a new Filter in the database.
 
     .. seealso:: :class:`msnoise.msnoise_table_def.declare_tables.Filter`
@@ -349,6 +349,12 @@ def update_filter(session, ref, low, mwcs_low, high, mwcs_high,
     :param mwcs_wlen: Window length (in seconds) to perform MWCS
     :type mwcs_step: float
     :param mwcs_step: Step (in seconds) of the windowing procedure in MWCS
+    :type dtt_minlag: float
+    :param dtt_minlag: If ``dtt_lag`` =static (in config table): min lag time (in seconds)
+    :type dtt_width: float
+    :param dtt_width: Width of the time lag window (in seconds)
+    :type dtt_v: float
+    :param dtt_v: If ``dttlag`` =dynamic (in config table): what velocity to use to avoid ballistic waves [1.0] km/s (default=1.0)
     :type used: bool
     :param used: Is the filter activated for the processing
     """
@@ -361,6 +367,9 @@ def update_filter(session, ref, low, mwcs_low, high, mwcs_high,
         filter.mwcs_high = mwcs_high
         filter.mwcs_wlen = mwcs_wlen
         filter.mwcs_step = mwcs_step
+        filter.dtt_minlag = dtt_minlag
+        filter.dtt_width = dtt_width
+        filter.dtt_v = dtt_v
         filter.used = used
         session.add(filter)
     else:
@@ -370,6 +379,9 @@ def update_filter(session, ref, low, mwcs_low, high, mwcs_high,
         filter.mwcs_high = mwcs_high
         filter.mwcs_wlen = mwcs_wlen
         filter.mwcs_step = mwcs_step
+        filter.dtt_minlag = dtt_minlag
+        filter.dtt_width = dtt_width
+        filter.dtt_v = dtt_v
         filter.used = used
     session.commit()
     return

--- a/msnoise/default.csv
+++ b/msnoise/default.csv
@@ -1,76 +1,74 @@
-name,default,definition,type,possible_values,used_in,
-data_folder,,Data Folder,str,,,
-output_folder,CROSS_CORRELATIONS,"CC Output Folder in case keep_all=Y, to store the individual windows. The daily CCF will always be stored in the STACKS/001_DAYS folder.",str,,,
-data_structure,SDS,"Either a predefined acronym [SDS]/BUD/IDDS, or /-separated path (e.g. NET/STA/YEAR/NET.STA.YEAR.DAY.MSEED).",str,,,
-archive_format,,"Force format of archive files to read? Leave empty for slightly slower auto-detection by Obspy, or specify any format supported by <a href='https://docs.obspy.org/packages/autogen/obspy.core.stream.read.html' target='_blank'>obspy.core.stream.read()</a>.",str,,,
-network,*,Network to analyse,str,,,
-channels,*,"Channels need to match the value (ex: [&ast;], &ast;Z, BH&ast;, HHZ,...)",str,,,
-startdate,1970-01-01,Start Date to process: [1970-01-01]='since beginning of the archive',str,,,
-enddate,2100-01-01,End Date to process: [2100-01-01]='No end',str,,,
-analysis_duration,86400,Duration of the Analysis in seconds (this shouldn't be changed for now),float,,,
-cc_sampling_rate,20,Sampling Rate for the CrossCorrelation (in Hz),float,,,
-cc_normalisation,NO,"Normalisation method for individual `corr_duration`) CCFs, default is not normalized (NO), but can be normalized based on the power of the two traces (POW), or by the maximum (MAX) or absolute maximum (ABSMAX) of the CCF",str,NO/POW/MAX/ABSMAX,,
-resampling_method,Decimate,Resampling method,str,Lanczos/Decimate,,
-preprocess_lowpass,8,Preprocessing Low-pass value (in Hz),float,,,
-preprocess_highpass,0.01,Preprocessing High-pass value (in Hz),float,,,
-preprocess_max_gap,10,Preprocessing maximum gap length that will be filled by interpolation (in seconds),float,,,
-preprocess_taper_length,20,"Duration of the taper applied at the beginning and end of trace during the preprocessing, to allow highpass filtering (in seconds)",float,,,
-remove_response,N,Remove instrument response,bool,Y/N,,
-response_format,dataless,Remove instrument file format,str,dataless/inventory/paz/resp,,
-response_path,inventory,"Instrument correction file(s) location (path relative to db.ini), defaults to './inventory', i.e. a subfolder in the current project folder. All files in that folder will be parsed.",str,,,
-response_prefilt,"(0.005, 0.006, 30.0, 35.0)","Remove instrument correction pre-filter (in Hz, see <a href='https://docs.obspy.org/packages/autogen/obspy.core.trace.Trace.remove_response.html' target=""_blank"">ObsPy Doc</a> for what it means.)",eval,,,
-maxlag,120,Maximum lag (in seconds),float,,,
-corr_duration,1800,Data windows to correlate (in seconds),float,,,
-overlap,0,Amount of overlap between data windows [0:1[,float,,,
-winsorizing,3,"Winsorizing at N time RMS , 0 disables winsorizing, -1 enables 1-bit normalization",float,,,
-whitening,A,"Whiten Traces before cross-correlation: [A]ll (except for autocorr), [N]one, or only if [C]omponents are different",str,A/N/C,,
-whitening_type,B,"Type of spectral whitening function to use: [B]rutal (amplitude to 1.0), divide spectrum by its [PSD] or by band-passing the white spectrum with a hanning-window [HANN]. WARNING: only works for compute_cc, not compute_cc_rot, where it will always be B",str,B/PSD/HANN,,
-clip_after_whiten,N,"Do the clipping (winsorizing) after whitening?",bool,Y/N,,
-stack_method,linear,Stack Method: Linear Mean or Phase Weighted Stack,str,linear/pws,,
-pws_timegate,10,"If ``stack_method`` ='pws', width of the smoothing (in seconds)",float,,,
-pws_power,2,"If ``stack_method`` =""pws"", Power of the Weighting",float,,,
-crondays,1,"Number of days to monitor with scan_archive, typically used in cron (should be a float representing a number of days, or a string designating weeks, days, and/or hours using the format 'Xw Xd Xh')",str,,,
-components_to_compute,ZZ,List (comma separated) of components to compute between two different stations,str,,,
-cc_type,CC,Cross-Correlation type,str,,,
-components_to_compute_single_station,,"List (comma separated) of components within a single station. ZZ would be the autocorrelation of Z component, while ZE or ZN are the cross-components. Defaults to [], no single-station computations are done.",str,,,
-cc_type_single_station_AC,CC,Auto-Correlation type,str,,,
-cc_type_single_station_SC,CC,Cross-Correlation type for Cross-Components,str,,,
-keep_all,Y,Keep all cross-corr (length: ``corr_duration``),bool,Y/N,,
-keep_days,Y,Keep all daily cross-corr,bool,Y/N,,
-ref_begin,1970-01-01,Beginning or REF stacks. Can be absolute (2012-01-01) or relative (-100) days,str,,,
-ref_end,2100-01-01,End or REF stacks. Same as ``ref_begin``,str,,,
-mov_stack,"(('1d','1d'))","A list of two parameters: the time to ""roll"" over (default 1 day) and the granularity (step) of the resulting stacked CCFs (default 1 day) to stack for the Moving-window stacks. This can be a list of tuples, e.g. (('1d','1d'),('2d','1d')) corresponds to the MSNoise 1.6 ""1,2"" before. Time deltas can be anything pandas can interpret (""d"", ""min"", ""sec"", etc).",eval,,,
-wienerfilt,N,"Apply wiener filter before stacking? Y[N]",bool,Y/N,,
-wiener_mlen,"24h","Smoothing along date axis (time delta)",str,,,
-wiener_nlen,"0.5s","Smoothing along lag time axis (time delta)",str,,,
-export_format,MSEED,Export stacks in which format(s) ?,str,SAC/MSEED/BOTH,,
-sac_format,doublets,Format for SAC stacks ?,str,doublets/clarke,,
-dtt_lag,static,How is the lag window defined,str,dynamic/static,,
-dtt_v,1,If ``dtt_lag`` =dynamic: what velocity to use to avoid ballistic wave (in km/s),float,,,
-dtt_minlag,5,If ``dtt_lag`` =static: min lag time (in seconds),float,,,
-dtt_width,30,Width of the time lag window (in seconds),float,,,
-dtt_sides,both,Which sides to use,str,both/left/right,,
-dtt_mincoh,0.65,"Minimum coherence on dt measurement, MWCS points with values lower than that will not be used in the WLS, [0:1]",float,,,
-dtt_maxerr,0.1,"Maximum error on dt measurement, MWCS points with values larger than that will not be used in the WLS [0:1]",float,,,
-dtt_maxdt,0.1,"Maximum dt values, MWCS points with values larger than that will not be used in the WLS (in seconds)",float,,,
-wct_ns,5,"smoothing parameter in frequency",float,,,
-wct_nt,5,"smoothing parameter in time",float,,,
-wct_vpo,20,"spacing param between discrete scales",float,,,
-wct_nptsfreq,300,"number of freq points between min and max",float,,,
-dtt_codacycles,20,"number of cycles of period (1/freq) between lag_min and lag_max",int,,,
-dvv_min_nonzero,0.25,"percentage of data points with non-zero weighting required for regression otherwise nan (0 to 1)",float,,,
-wct_norm,Y,"Is the REF and CCF are normalized before computing wavelet? [Y]/N",bool,Y/N,,
-wavelet_type,"('Morlet',6.)","Wavelet type and optional associated parameter",eval,Morlet/Paul/DOG/MexicanHat,,
-plugins,,Comma separated list of plugin names. Plugins names should be importable Python modules.,str,,,
-hpc,N,Is MSNoise going to run on an HPC?,bool,Y/N,,
-stretching_max,0.01,"Maximum stretching coefficient, e.g. 0.5 = 50%, 0.01 = 1%",float,,,
-stretching_nsteps,1000,Number of stretching steps between 1- ``stretching_max`` and 1+ ``stretching_max``,int,,,
-qc_components,Z,"Components to process for QC, defaults to [Z], but can be any comma separated list (e.g. 'Z,E,N')",str,,,
-qc_ppsd_length,3600,Length of data segments passed to psd in seconds. In the paper by McNamara et al (2004) a value of 3600 (1 hour) was chosen. Longer segments increase the upper limit of analyzed periods but decrease the number of analyzed segments.,float,,,
-qc_ppsd_overlap,0,"Overlap of segments passed to psd. Overlap may take values between 0 and 1 and is given as fraction of the length of one segment, e.g. `qc_ppsd_length=3600` and `qc_ppsd_overlap=0.5` result in an overlap of 1800s of the segments.",float,,,
-qc_ppsd_period_smoothing_width_octaves,0.125,Determines over what period/frequency range the psd is smoothed around every central period/frequency. Given in fractions of octaves (default of ``1`` means the psd is averaged over a full octave at each central frequency).,float,,,
-qc_ppsd_period_step_octaves,0.0125,Step length on frequency axis in fraction of octaves (default of ``0.125`` means one smoothed psd value on the frequency axis is measured every 1/8 of an octave).,float,,,
-qc_ppsd_period_limits,"(0.01,100)","Set custom lower and upper end of period range (e.g. ``(0.01, 100)`` seconds). The specified lower end of period range will be set as the central period of the first bin (geometric mean of left/right edges of smoothing interval). At the upper end of the specified period range, no more additional bins will be added after the bin whose center frequency exceeds the given upper end for the first time.",eval,,,
-qc_ppsd_db_bins,"(-200, -50, 1.)",Specify the lower and upper boundary and the width of the db bins. The bin width might get adjusted to fit a number of equally spaced bins in between the given boundaries.,eval,,,
-qc_rms_frequency_ranges,"[(1.0, 20.0), (4.0, 14.0), (4.0, 40.0), (4.0, 9.0)]",Specify the frequency bounds (in Hz) to compute the RMS from PSDs,eval,,,
-qc_rms_type,DISP,What units do you want for the exported RMS,str,DISP/VEL/ACC,,
+name,default,definition,type,possible_values,used_in
+data_folder,,Data Folder,str,,"[scan_archive]"
+output_folder,CROSS_CORRELATIONS,"CC Output Folder in case keep_all=Y, to store the individual windows. The daily CCF will always be stored in the STACKS/001_DAYS folder.",str,,"[compute_cc]"
+data_structure,SDS,"Either a predefined acronym [SDS]/BUD/IDDS, or /-separated path (e.g. NET/STA/YEAR/NET.STA.YEAR.DAY.MSEED).",str,,"[scan_archive]"
+archive_format,,"Force format of archive files to read? Leave empty for slightly slower auto-detection by Obspy, or specify any format supported by <a href='https://docs.obspy.org/packages/autogen/obspy.core.stream.read.html' target='_blank'>obspy.core.stream.read()</a>.",str,,"[scan_archive]"
+network,*,Network to analyse,str,,"[scan_archive]"
+channels,*,"Channels need to match the value (ex: [&ast;], &ast;Z, BH&ast;, HHZ,...)",str,,"[scan_archive]"
+startdate,1970-01-01,Start Date to process: [1970-01-01]='since beginning of the archive',str,,"[scan_archive]"
+enddate,2100-01-01,End Date to process: [2100-01-01]='No end',str,,"[scan_archive]"
+analysis_duration,86400,Duration of the Analysis in seconds (this shouldn't be changed for now),float,,"[compute_cc]"
+cc_sampling_rate,20,Sampling Rate for the CrossCorrelation (in Hz),float,,"[compute_cc]"
+cc_normalisation,NO,"Normalisation method for individual `corr_duration`) CCFs, default is not normalized (NO), but can be normalized based on the power of the two traces (POW), or by the maximum (MAX) or absolute maximum (ABSMAX) of the CCF",str,NO/POW/MAX/ABSMAX,"[compute_cc]"
+resampling_method,Decimate,Resampling method,str,Lanczos/Decimate,"[compute_cc]"
+preprocess_lowpass,8,Preprocessing Low-pass value (in Hz),float,,"[compute_cc]"
+preprocess_highpass,0.01,Preprocessing High-pass value (in Hz),float,,"[compute_cc]"
+preprocess_max_gap,10,Preprocessing maximum gap length that will be filled by interpolation (in seconds),float,,"[compute_cc]"
+preprocess_taper_length,20,"Duration of the taper applied at the beginning and end of trace during the preprocessing, to allow highpass filtering (in seconds)",float,,"[compute_cc]"
+remove_response,N,Remove instrument response,bool,Y/N,"[compute_cc]"
+response_format,dataless,Remove instrument file format,str,dataless/inventory/paz/resp,"[compute_cc]"
+response_path,inventory,"Instrument correction file(s) location (path relative to db.ini), defaults to './inventory', i.e. a subfolder in the current project folder. All files in that folder will be parsed.",str,,"[compute_cc]"
+response_prefilt,"(0.005, 0.006, 30.0, 35.0)","Remove instrument correction pre-filter (in Hz, see <a href='https://docs.obspy.org/packages/autogen/obspy.core.trace.Trace.remove_response.html' target=""_blank"">ObsPy Doc</a> for what it means.)",eval,,"[compute_cc]"
+maxlag,120,Maximum lag (in seconds),float,,"[compute_cc]"
+corr_duration,1800,Data windows to correlate (in seconds),float,,"[compute_cc]"
+overlap,0,Amount of overlap between data windows [0:1[,float,,"[compute_cc]"
+winsorizing,3,"Winsorizing at N time RMS , 0 disables winsorizing, -1 enables 1-bit normalization",float,,"[compute_cc]"
+whitening,A,"Whiten Traces before cross-correlation: [A]ll (except for autocorr), [N]one, or only if [C]omponents are different",str,A/N/C,"[compute_cc]"
+whitening_type,B,"Type of spectral whitening function to use: [B]rutal (amplitude to 1.0), divide spectrum by its [PSD] or by band-passing the white spectrum with a hanning-window [HANN]. WARNING: only works for compute_cc, not compute_cc_rot, where it will always be B",str,B/PSD/HANN,"[compute_cc]"
+clip_after_whiten,N,Do the clipping (winsorizing) after whitening?,bool,Y/N,"[compute_cc]"
+stack_method,linear,Stack Method: Linear Mean or Phase Weighted Stack,str,linear/pws,"[compute_cc,stack]"
+pws_timegate,10,"If ``stack_method`` ='pws', width of the smoothing (in seconds)",float,,"[compute_cc,stack]"
+pws_power,2,"If ``stack_method`` =""pws"", Power of the Weighting",float,,"[compute_cc,stack]"
+crondays,1,"Number of days to monitor with scan_archive, typically used in cron (should be a float representing a number of days, or a string designating weeks, days, and/or hours using the format 'Xw Xd Xh')",str,,"[scan_archive]"
+components_to_compute,ZZ,List (comma separated) of components to compute between two different stations,str,,"[compute_cc]"
+cc_type,CC,Cross-Correlation type,str,,"[compute_cc]"
+components_to_compute_single_station,,"List (comma separated) of components within a single station. ZZ would be the autocorrelation of Z component, while ZE or ZN are the cross-components. Defaults to [], no single-station computations are done.",str,,"[compute_cc]"
+cc_type_single_station_AC,CC,Auto-Correlation type,str,,"[compute_cc]"
+cc_type_single_station_SC,CC,Cross-Correlation type for Cross-Components,str,,"[compute_cc]"
+keep_all,Y,Keep all cross-corr (length: ``corr_duration``),bool,Y/N,"[compute_cc]"
+keep_days,Y,Keep all daily cross-corr,bool,Y/N,"[compute_cc]"
+ref_begin,1970-01-01,Beginning or REF stacks. Can be absolute (2012-01-01) or relative (-100) days,str,,"[stack]"
+ref_end,2100-01-01,End or REF stacks. Same as ``ref_begin``,str,,"[stack]"
+mov_stack,"(('1d','1d'))","A list of two parameters: the time to ""roll"" over (default 1 day) and the granularity (step) of the resulting stacked CCFs (default 1 day) to stack for the Moving-window stacks. This can be a list of tuples, e.g. (('1d','1d'),('2d','1d')) corresponds to the MSNoise 1.6 ""1,2"" before. Time deltas can be anything pandas can interpret (""d"", ""min"", ""sec"", etc).",eval,,"[stack]"
+wienerfilt,N,Apply wiener filter before stacking? Y[N],bool,Y/N,"[stack]"
+wiener_mlen,24h,Smoothing along date axis (time delta),str,,"[stack]"
+wiener_nlen,0.5s,Smoothing along lag time axis (time delta),str,,"[stack]"
+export_format,MSEED,Export stacks in which format(s) ?,str,SAC/MSEED/BOTH,"[compute_cc]"
+sac_format,doublets,Format for SAC stacks ?,str,doublets/clarke,"[compute_cc]"
+dtt_lag,static,How is the lag window defined [static]/dynamic. Note that min lag and width are defined for each filter individually in Filter table),str,dynamic/static,"[compute_dtt, compute_stretching]"
+dtt_sides,both,Which sides to use,str,both/left/right,"[compute_dtt, compute_stretching]"
+dtt_mincoh,0.65,"Minimum coherence on dt measurement, MWCS points with values lower than that will not be used in the WLS, [0:1]",float,,"[compute_dtt, compute_stretching, compute_wct]"
+dtt_maxerr,0.1,"Maximum error on dt measurement, MWCS points with values larger than that will not be used in the WLS [0:1]",float,,"[compute_dtt]"
+dtt_maxdt,0.1,"Maximum dt values, MWCS points with values larger than that will not be used in the WLS (in seconds)",float,,"[compute_dtt]"
+wct_ns,5,smoothing parameter in frequency,float,,"[compute_wct]"
+wct_nt,5,smoothing parameter in time,float,,"[compute_wct]"
+wct_vpo,20,spacing param between discrete scales,float,,"[compute_wct]"
+wct_nptsfreq,300,number of freq points between min and max,float,,"[compute_wct]"
+wct_minlag,5,min lag time (in seconds),float,,"[compute_wct]"
+wct_codacycles,20,number of cycles of period (1/freq) between lag_min and lag_max,int,,"[compute_wct]"
+wct_min_nonzero,0.25,percentage of data points with non-zero weighting required for regression otherwise nan (0 to 1),float,,"[compute_wct]"
+wct_norm,Y,Is the REF and CCF are normalized before computing wavelet? [Y]/N,bool,Y/N,"[compute_wct]"
+wavelet_type,"('Morlet',6.)",Wavelet type and optional associated parameter,eval,Morlet/Paul/DOG/MexicanHat,"[compute_wct]"
+plugins,,Comma separated list of plugin names. Plugins names should be importable Python modules.,str,,"[misc]"
+hpc,N,Is MSNoise going to run on an HPC?,bool,Y/N,"[misc]"
+stretching_max,0.01,"Maximum stretching coefficient, e.g. 0.5 = 50%, 0.01 = 1%",float,,"[compute_stretching]"
+stretching_nsteps,1000,Number of stretching steps between 1- ``stretching_max`` and 1+ ``stretching_max``,int,,"[compute_stretching]"
+qc_components,Z,"Components to process for QC, defaults to [Z], but can be any comma separated list (e.g. 'Z,E,N')",str,,"[qc]"
+qc_ppsd_length,3600,Length of data segments passed to psd in seconds. In the paper by McNamara et al (2004) a value of 3600 (1 hour) was chosen. Longer segments increase the upper limit of analyzed periods but decrease the number of analyzed segments.,float,,"[qc]"
+qc_ppsd_overlap,0,"Overlap of segments passed to psd. Overlap may take values between 0 and 1 and is given as fraction of the length of one segment, e.g. `qc_ppsd_length=3600` and `qc_ppsd_overlap=0.5` result in an overlap of 1800s of the segments.",float,,"[qc]"
+qc_ppsd_period_smoothing_width_octaves,0.125,Determines over what period/frequency range the psd is smoothed around every central period/frequency. Given in fractions of octaves (default of ``1`` means the psd is averaged over a full octave at each central frequency).,float,,"[qc]"
+qc_ppsd_period_step_octaves,0.0125,Step length on frequency axis in fraction of octaves (default of ``0.125`` means one smoothed psd value on the frequency axis is measured every 1/8 of an octave).,float,,"[qc]"
+qc_ppsd_period_limits,"(0.01,100)","Set custom lower and upper end of period range (e.g. ``(0.01, 100)`` seconds). The specified lower end of period range will be set as the central period of the first bin (geometric mean of left/right edges of smoothing interval). At the upper end of the specified period range, no more additional bins will be added after the bin whose center frequency exceeds the given upper end for the first time.",eval,,"[qc]"
+qc_ppsd_db_bins,"(-200, -50, 1.)",Specify the lower and upper boundary and the width of the db bins. The bin width might get adjusted to fit a number of equally spaced bins in between the given boundaries.,eval,,"[qc]"
+qc_rms_frequency_ranges,"[(1.0, 20.0), (4.0, 14.0), (4.0, 40.0), (4.0, 9.0)]",Specify the frequency bounds (in Hz) to compute the RMS from PSDs,eval,,"[qc]"
+qc_rms_type,DISP,What units do you want for the exported RMS,str,DISP/VEL/ACC,"[qc]"

--- a/msnoise/msnoise_table_def.py
+++ b/msnoise/msnoise_table_def.py
@@ -91,6 +91,12 @@ def declare_tables(prefix=None):
         :param mwcs_wlen: Window length (in seconds) to perform MWCS
         :type mwcs_step: float
         :param mwcs_step: Step (in seconds) of the windowing procedure in MWCS
+        :type dtt_minlag: float
+        :param dtt_minlag: If ``dtt_lag`` =static (in config table): min lag time (in seconds)
+        :type dtt_width: float
+        :param dtt_width: Width of the time lag window (in seconds)
+        :type dtt_v: float
+        :param dtt_v: If ``dttlag`` =dynamic (in config table): what velocity to use to avoid ballistic waves [1.0] km/s (default=1.0)
         :type used: bool
         :param used: Is the filter activated for the processing
         """
@@ -104,6 +110,9 @@ def declare_tables(prefix=None):
         mwcs_high = Column(Float())
         mwcs_wlen = Column(Float())
         mwcs_step = Column(Float())
+        dtt_minlag = Column(Float())
+        dtt_width = Column(Float())
+        dtt_v = Column(Float())
         used = Column(Boolean(True))
 
         def __init__(self, **kwargs):
@@ -114,6 +123,9 @@ def declare_tables(prefix=None):
             # self.mwcs_high = mwcs_high
             # self.mwcs_wlen = mwcs_wlen
             # self.mwcs_step = mwcs_step
+            # self.dtt_minlag = dtt_minlag
+            # self.dtt_width = dtt_width
+            # self.dtt_v = dtt_v
             # self.used = used
 
     ########################################################################
@@ -231,12 +243,14 @@ def declare_tables(prefix=None):
         """
         __incomplete_tablename__ = "config"
         name = Column(String(255), primary_key=True)
-        value = Column(String(255))
+        value = Column(String(255))      
+        used_in = Column(String(255))
 
-        def __init__(self, name, value):
+        def __init__(self, name, value, used_in):
             """"""
             self.name = name
             self.value = value
+            self.used_in = used_in
 
     ########################################################################
 

--- a/msnoise/s000installer.py
+++ b/msnoise/s000installer.py
@@ -238,7 +238,7 @@ def main(tech=None, hostname=None, username=None, password=None,
 
     # Add default configuration values to the database
     for name in default.keys():
-        session.add(schema.Config(name=name, value=default[name].default))
+        session.add(schema.Config(name=name, value=default[name].default, used_in=default[name].used_in))
 
     try:
         session.commit()

--- a/msnoise/s06compute_dtt2.py
+++ b/msnoise/s06compute_dtt2.py
@@ -97,13 +97,13 @@ def main(interval=1, loglevel="INFO"):
                     tArray = M.columns.values
 
                     if params.dtt_lag == "static":
-                        lmlag = -params.dtt_minlag
-                        rmlag = params.dtt_minlag
+                        lmlag = -f.dtt_minlag
+                        rmlag = f.dtt_minlag
                     else:
-                        lmlag = -dist / params.dtt_v
-                        rmlag = dist / params.dtt_v
-                    lMlag = lmlag - params.dtt_width
-                    rMlag = rmlag + params.dtt_width
+                        lmlag = -dist / f.dtt_v
+                        rmlag = dist / f.dtt_v
+                    lMlag = lmlag - f.dtt_width
+                    rMlag = rmlag + f.dtt_width
 
                     if params.dtt_sides == "both":
                         tindex = np.where(

--- a/msnoise/s08compute_wct.py
+++ b/msnoise/s08compute_wct.py
@@ -5,15 +5,15 @@ This script performs the computation of the Wavelet Coherence Transform (WCT), a
 Filter Configuration Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* |dtt_minlag|
+* |wct_minlag|
 * |dtt_maxdt|
 * |dtt_mincoh|
-* |dtt_codacycles|
+* |wct_codacycles|
 * |wct_ns|
 * |wct_nt|
 * |wct_vpo|
 * |wct_nptsfreq|
-* |dvv_min_nonzero|
+* |wct_min_nonzero|
 * |wct_norm|
 * |hpc|
 
@@ -361,14 +361,14 @@ def main(loglevel="INFO"):
     nt = params.wct_nt 
     vpo = params.wct_vpo 
     nptsfreq = params.wct_nptsfreq
-    coda_cycles = params.dtt_codacycles 
-    min_nonzero = params.dvv_min_nonzero
+    coda_cycles = params.wct_codacycles 
+    min_nonzero = params.wct_min_nonzero
     wct_norm = params.wct_norm
     wavelet_type = params.wavelet_type
     
     mov_stacks = params.mov_stack
     goal_sampling_rate = params.cc_sampling_rate
-    lag_min = params.dtt_minlag
+    lag_min = params.wct_minlag
     maxdt = params.dtt_maxdt
     mincoh = params.dtt_mincoh
 

--- a/msnoise/stretch2.py
+++ b/msnoise/stretch2.py
@@ -196,7 +196,7 @@ def main(loglevel="INFO"):
 
                 # zero the data outside of the minlag-maxlag timing
                 if params.dtt_lag == "static":
-                    minlag = params.dtt_minlag
+                    minlag = f.dtt_minlag
                 else:
                     SS1 = station1.split(".")
                     SS2 = station2.split(".")
@@ -204,8 +204,8 @@ def main(loglevel="INFO"):
                     SS1 = get_station(db, SS1[0], SS1[1])
                     SS2 = get_station(db, SS2[0], SS2[1])
                     minlag = get_interstation_distance(SS1, SS2,
-                                                       SS1.coordinates) / params.dtt_v
-                maxlag2 = minlag + params.dtt_width
+                                                       SS1.coordinates) / f.dtt_v
+                maxlag2 = minlag + f.dtt_width
                 mid = int(params.goal_sampling_rate * params.maxlag)
                 print("betweeen", minlag, "and", maxlag2    )
                 ref[mid - int(minlag * goal_sampling_rate):mid + int(

--- a/msnoise/test/tests-threecomponent.py
+++ b/msnoise/test/tests-threecomponent.py
@@ -170,13 +170,16 @@ def test_004_set_and_get_filters():
     f.mwcs_high = 5
     f.mwcs_wlen = 5
     f.mwcs_step = 2
+    f.dtt_minlag = 5
+    f.dtt_width = 30
+    f.dtt_v = 1
     f.used = True
     filters.append(f)
     for f in filters:
-        update_filter(db, f.ref, f.low, f.mwcs_low, f.high, f.mwcs_high, f.mwcs_wlen, f.mwcs_step, f.used)
+        update_filter(db, f.ref, f.low, f.mwcs_low, f.high, f.mwcs_high, f.mwcs_wlen, f.mwcs_step, f.dtt_minlag, f.dtt_width, f.dtt_v, f.used)
     dbfilters = get_filters(db)
     for i, filter in enumerate(dbfilters):
-        for param in ['low', 'mwcs_low', 'high', 'mwcs_high', 'mwcs_wlen', 'mwcs_step', 'used']:
+        for param in ['low', 'mwcs_low', 'high', 'mwcs_high', 'mwcs_wlen', 'mwcs_step', 'dtt_minlag', 'dtt_width', 'dtt_v', 'used']:
             assert eval(f"filter.{param}") == eval(f"filters[i].{param}")
 
 @pytest.mark.order(5)

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -156,6 +156,9 @@ def test_004_set_and_get_filters():
     f.mwcs_high = 0.98
     f.mwcs_wlen = 10
     f.mwcs_step = 5
+    f.dtt_minlag = 5
+    f.dtt_width = 30
+    f.dtt_v = 1
     f.used = True
     filters.append(f)
     f = Filter()
@@ -165,6 +168,9 @@ def test_004_set_and_get_filters():
     f.mwcs_high = 0.98
     f.mwcs_wlen = 10
     f.mwcs_step = 5
+    f.dtt_minlag = 5
+    f.dtt_width = 30
+    f.dtt_v = 1
     f.used = True
     filters.append(f)
     for f in filters:

--- a/msnoise/test/tests.py
+++ b/msnoise/test/tests.py
@@ -174,10 +174,11 @@ def test_004_set_and_get_filters():
     f.used = True
     filters.append(f)
     for f in filters:
-        update_filter(db, f.ref, f.low, f.mwcs_low, f.high, f.mwcs_high, f.mwcs_wlen, f.mwcs_step, f.used)
+        print(f)
+        update_filter(db, f.ref, f.low, f.mwcs_low, f.high, f.mwcs_high, f.mwcs_wlen, f.mwcs_step, f.dtt_minlag, f.dtt_width, f.dtt_v, f.used)
     dbfilters = get_filters(db)
     for i, filter in enumerate(dbfilters):
-        for param in ['low', 'mwcs_low', 'high', 'mwcs_high', 'mwcs_wlen', 'mwcs_step', 'used']:
+        for param in ['low', 'mwcs_low', 'high', 'mwcs_high', 'mwcs_wlen', 'mwcs_step', 'dtt_minlag', 'dtt_width', 'dtt_v', 'used']:
             assert eval(f"filter.{param}") == eval(f"filters[i].{param}")
 
 @pytest.mark.order(5)


### PR DESCRIPTION
Afew things added/changed. I still want to make some further adjustments (listed below), but if there is any feedback on these changes i.e. whether they're wanted or not, or if there is a better way of doing it, would be useful before merging.

**Changes:**

- dtt_minlag, dtt_width, and dtt_v, moved to filter table. I've always personally, at least for dtt_minlag and dtt_width, adjusted the code to have these defined for individually for each filter as makes the most sense to me. 

- config sql table contains used_in field which is a list of steps where it is used/defined. It can be used as a filter on msnoise admin (originally was looking to do this without having it as a column in the sql table, only in defaults.csv, but was easier just including it in the config table... and just not showing it on admin).

- adjusted  some of parameters in wavelet codes (from using 'dtt' to 'wct') to make it clear they are wavelet related, e.g. wct_minlag, wct_codacycles, wct_min_nonzero. Might rename some of these variables anyway actually, as i just chose them quickly when writing the code.

**Some images of the changes**

filter table new columns:
![filter_admin1](https://github.com/user-attachments/assets/6d5e28cd-688f-4e03-af4d-c689ff3732c1)

dropdown option in config with used_in filter:
![msnoise_admin3](https://github.com/user-attachments/assets/dc141aaa-16fd-41ed-bb30-56236f7cd346)
![msnoise_admin2](https://github.com/user-attachments/assets/3763b341-0b65-4c1b-a25f-1a99afa00206)

wct param name changes:
![msnoise_admin4](https://github.com/user-attachments/assets/3f3923ef-e126-4c12-9dec-6b08e66f4423)**

**To do (related to param changes)**

- Double check documentation, probably needs some updates.
- Adjust wavelet code to also include option for static lag times. Also, some of the 'default' choices should be changed.

As said, feedback welcome re. any of this!