### PR TITLE
feat(plot): use PyGMT for station map (remade on top of the current master)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,3 +11,4 @@ Lukas E. Preiswerk
 Carmelo Sammarco
 Arnaud Watlet
 Alec Yates
+Hong-Mao Huang

--- a/msnoise/plots/station_map.py
+++ b/msnoise/plots/station_map.py
@@ -1,11 +1,7 @@
 """
-This plots a very raw station map (needs improvement). This plot requires
+This plots a station map using PyGMT.
+
 .. include:: /clickhelp/msnoise-plot-station_map.rst
-
-cartopy !
-
-
-
 
 Example:
 
@@ -13,111 +9,128 @@ Example:
 
 .. image:: ../.static/station_map.png
 
-
 It will also generate a HTML file showing the stations on the Leaflet Mapping
 Service:
 
 .. raw:: html
 
     <iframe src="_static/station_map.html" width=800 height=400></iframe>
-
-
-
 """
 
 import datetime
 import logging
-import traceback
 
 import numpy as np
-import matplotlib.pyplot as plt
-
 
 from ..core.db import connect
 from ..core.stations import get_stations
 
 
-def main(show=True, outfile=None):
-    from mpl_toolkits.basemap import Basemap
+def _outfile_name(outfile):
+    if outfile and outfile.startswith("?"):
+        now = datetime.datetime.now()
+        now = now.strftime("station map on %Y-%m-%d %H.%M.%S")
+        return outfile.replace("?", now)
+    return outfile
+
+
+def _plot_leaflet(stations, coords, outfile):
     import folium
+
+    sta_map = folium.Map(
+        location=[np.mean(coords[:, 0]), np.mean(coords[:, 1])],
+        zoom_start=3,
+        tiles="OpenStreetMap",
+    )
+    folium.RegularPolygonMarker(
+        location=[np.mean(coords[:, 0]), np.mean(coords[:, 1])]
+    ).add_to(sta_map)
+
+    for sta in stations:
+        folium.RegularPolygonMarker(
+            location=[sta.Y, sta.X],
+            popup="%s_%s" % (sta.net, sta.sta),
+            fill_color="red",
+            number_of_sides=3,
+            radius=12,
+        ).add_to(sta_map)
+
+    sta_map.add_child(folium.LatLngPopup())
+
+    if outfile:
+        logging.debug("output to: %s.html" % outfile)
+        sta_map.save("%s.html" % outfile)
+
+
+def _plot_pygmt(stations, coords, show=True, outfile=None):
+    try:
+        import pygmt
+    except ImportError:
+        raise ImportError(
+            "PyGMT is required to plot station maps. "
+            "Please install pygmt to use `msnoise plot station_map`."
+        )
+
+    lats = coords[:, 0]
+    lons = coords[:, 1]
+    labels = ["%s_%s" % (sta.net, sta.sta) for sta in stations]
+
+    bufferlat = (np.amax(lats) - np.amin(lats)) + 0.1
+    bufferlon = (np.amax(lons) - np.amin(lons)) + 0.1
+    region = [
+        np.amin(lons) - bufferlon,
+        np.amax(lons) + bufferlon,
+        np.amin(lats) - bufferlat,
+        np.amax(lats) + bufferlat,
+    ]
+
+    fig = pygmt.Figure()
+    fig.coast(
+        region=region,
+        projection="M15c",
+        resolution="i",
+        land="lightgray",
+        water="lightblue",
+        shorelines="0.5p,black",
+        borders=["1/0.5p,black"],
+        frame=["a", "+tStation map"],
+    )
+    fig.plot(x=lons, y=lats, style="i0.4c", fill="red", pen="0.25p,black")
+    fig.text(
+        x=lons,
+        y=lats,
+        text=labels,
+        font="9p,Helvetica,black",
+        justify="CB",
+        offset="0/0.25c",
+        fill="white",
+        pen="0.25p,black",
+        transparency=30,
+    )
+
+    if outfile:
+        logging.info("output to: %s" % outfile)
+        fig.savefig(outfile)
+
+    if show:
+        fig.show()
+
+
+def main(show=True, outfile=None):
     db = connect()
     stations = get_stations(db, all=False)
     coords = [(sta.Y, sta.X) for sta in stations]
     coords = np.array(coords)
 
-    sta_map = folium.Map(location=[np.mean(coords[:, 0]),
-                                   np.mean(coords[:, 1])],
-                         zoom_start=3, tiles='OpenStreetMap')
-    folium.RegularPolygonMarker(location=[np.mean(coords[:, 1]),
-                                          np.mean(coords[:, 0])]).\
-        add_to(sta_map)
-    for sta in stations:
-        folium.RegularPolygonMarker(location=[sta.Y, sta.X],
-                                    popup="%s_%s" % (sta.net, sta.sta),
-                                    fill_color='red',
-                                    number_of_sides=3,
-                                    radius=12).add_to(sta_map)
+    if not len(coords):
+        logging.warning("No station found. Nothing to plot.")
+        return
 
-    sta_map.add_child(folium.LatLngPopup())
-    if outfile:
-        tmp = outfile
-        if outfile.startswith("?"):
-            now = datetime.datetime.now()
-            now = now.strftime('station map on %Y-%m-%d %H.%M.%S')
-            tmp = outfile.replace('?', now)
-        logging.debug("output to: %s" % tmp)
-        sta_map.save('%s.html' % tmp)
+    outfile = _outfile_name(outfile)
 
-    # plot topography/bathymetry as an image.
-    bufferlat = (np.amax(coords[:, 0])-np.amin(coords[:, 0]))+.1
-    bufferlon = (np.amax(coords[:, 1])-np.amin(coords[:, 1]))+.1
-    m = Basemap(projection='mill', llcrnrlat=np.amin(coords[:, 0])-bufferlat,
-                urcrnrlat=np.amax(coords[:, 0])+bufferlat,
-                llcrnrlon=np.amin(coords[:, 1])-bufferlon,
-                urcrnrlon=np.amax(coords[:, 1])+bufferlon, resolution='i')
+    _plot_leaflet(stations, coords, outfile)
+    _plot_pygmt(stations, coords, show=show, outfile=outfile)
 
-    # Draw station coordinates
-    x, y = m(coords[:, 1], coords[:, 0])
-
-    # create new figure, axes instance.
-    fig = plt.figure()
-    ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
-    # attach new axes image to existing Basemap instance.
-    m.ax = ax
-    try:
-        m.shadedrelief()
-    except Exception:
-        traceback.print_exc()
-    m.scatter(x, y, 50, marker='v', color='r')
-    for sta in stations:
-        xpt, ypt = m(sta.X, sta.Y)
-        plt.text(xpt, ypt, "%s_%s" % (sta.net, sta.sta), fontsize=9,
-                 ha='center', va='top', color='k',
-                 bbox=dict(boxstyle="square", ec='None', fc=(1, 1, 1, 0.5)))
-    # draw coastlines and political boundaries.
-    m.drawcoastlines()
-    m.drawcountries()
-    m.drawstates()
-    # draw parallels and meridians.
-    # label on left and bottom of map.
-    parallels = np.arange(-90, 90, 10.)
-    m.drawparallels(parallels, labels=[1, 0, 0, 1])
-    meridians = np.arange(0., 360., 10.)
-    m.drawmeridians(meridians, labels=[1, 0, 0, 1])
-    # add colorbar
-    ax.set_title('Station map')
-
-    if outfile:
-        if outfile.startswith("?"):
-            now = datetime.datetime.now()
-            now = now.strftime('station map on %Y-%m-%d %H.%M.%S')
-            outfile = outfile.replace('?', now)
-        logging.info("output to: %s" % outfile)
-        plt.savefig(outfile)
-    if show:
-        plt.show()
-    else:
-        plt.close()
 
 if __name__ == "__main__":
     main()

--- a/msnoise/scripts/msnoise.py
+++ b/msnoise/scripts/msnoise.py
@@ -1410,7 +1410,7 @@ def plot_data_availability(ctx, chan, show, outfile):
 @outfile_option
 @click.pass_context
 def plot_station_map(ctx, show, outfile):
-    """Plots the station map (very very basic)"""
+    """Plots the station map"""
     if ctx.obj['MSNOISE_custom']:
         from station_map import main # NOQA
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "flask-wtf",
     "markdown",
     "folium",
-    "pygmt",
     "wtforms<3.2",        # flask-admin compat: wtforms>=3.2 breaks form rendering
     "jinja2",
     # "scandir",            # Python 2 backport; os.scandir is stdlib since Python 3.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "flask-wtf",
     "markdown",
     "folium",
+    "pygmt",
     "wtforms<3.2",        # flask-admin compat: wtforms>=3.2 breaks form rendering
     "jinja2",
     # "scandir",            # Python 2 backport; os.scandir is stdlib since Python 3.5


### PR DESCRIPTION
Hello Thomas,

I remade the station_map PyGMT PR on top of the current master. This version keeps the changes focused on the station_map plotting command and switches the static station map output from Basemap/Matplotlib to PyGMT. The existing Folium HTML output is still preserved.

Changes:
- Replace the Basemap-based station_map rendering with PyGMT.
- Add PyGMT as a project dependency.
- Keep the existing `msnoise plot station_map` CLI interface unchanged.
- Update the station_map command help text.
- Add my name to `CONTRIBUTORS.txt`.

This supersedes #429.